### PR TITLE
fix(release): normalize VERSION file content before comparison with tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
             echo "VERSION file not found in repository root"
             exit 1
           fi
-          VERSION_FILE="$(cat VERSION)"
-          VERSION_FILE="${VERSION_FILE##v}"
+          VERSION_FILE="$(tr -d '[:space:]' < VERSION)"
+          VERSION_NORMALIZED="${VERSION_FILE##v}"
           TAG_STRIPPED="${TAG_NAME##v}"
-          if [[ "$VERSION_FILE" != "$TAG_STRIPPED" ]]; then
+          if [[ "$VERSION_NORMALIZED" != "$TAG_STRIPPED" ]]; then
             echo "Tag ($TAG_NAME) does not match VERSION file ($VERSION_FILE)"
             exit 1
           fi


### PR DESCRIPTION
This pull request makes a small improvement to the release workflow by ensuring that any whitespace in the `VERSION` file is removed before comparing it to the tag name. This helps prevent release failures due to formatting issues in the `VERSION` file.