### PR TITLE
chore(ci): update CodeQL and Bandit configurations for improved scanning

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -3,4 +3,9 @@ name: "CodeQL Config"
 paths-ignore:
   - tests/**
   - '**/*test*.py'
+  - docs/**
+  - htmlcov/**
+  - dist/**
+  - assets/**
+  - .venv/**
 

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -39,14 +39,14 @@ jobs:
           exit_zero: true # optional, default is DEFAULT
           # Github token of the repository (automatically created by Github)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information.
-          # File or directory to run bandit on
-          # path: # optional, default is .
+          # Limit scanning to first-party runtime code.
+          path: src,web,run.py
           # Report only issues of a given severity level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
           # level: # optional, default is UNDEFINED
           # Report only issues of a given confidence level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
           # confidence: # optional, default is UNDEFINED
-          # comma-separated list of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file) (default: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
-          # excluded_paths: # optional, default is DEFAULT
+          # Exclude tests and generated artifacts to avoid noisy findings.
+          excluded_paths: tests,docs,htmlcov,dist,.venv
           # comma-separated list of test IDs to skip
           # skips: # optional, default is DEFAULT
           # path to a .bandit file that supplies command line arguments

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -13,13 +13,7 @@
 name: Codacy Security Scan
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
-  schedule:
-    - cron: '21 13 * * 3'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates the project's security and code quality workflow configurations to improve scan accuracy and efficiency. The most significant changes are focused on narrowing the scope of automated security scans to exclude non-runtime code and generated artifacts, and on modifying when certain workflows are triggered.

**Security scan configuration improvements:**

* [`.github/codeql-config.yml`](diffhunk://#diff-7d4f1a7ea2c5e1e83f329311bc7b5f2c5337c2a405b859beed956954fbc0012fR6-R10): Expanded the `paths-ignore` section to exclude documentation, coverage reports, distribution artifacts, static assets, and virtual environments from CodeQL analysis, reducing noise and improving scan relevance.
* [`.github/workflows/bandit.yml`](diffhunk://#diff-1a7111f8a310855b068faadb95060baf0e8b78208a5009ce3ed1fff0ef459ddaL42-R49): Limited Bandit security scanning to first-party runtime code (`src`, `web`, `run.py`) and explicitly excluded tests, documentation, coverage reports, distribution artifacts, and virtual environments to avoid irrelevant findings.

**Workflow trigger adjustments:**

* [`.github/workflows/codacy.yml`](diffhunk://#diff-f0d3530b5eea10fe26ad541e683cfb4072e290804705de6abf6a5b2e80a72f59L16-R16): Changed the Codacy Security Scan workflow to run only on manual dispatch (`workflow_dispatch`), instead of on every push, pull request, or scheduled interval, giving more control over when scans are performed.