### PR TITLE
chore: update project to require Python 3.11 and adjust related configurations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ locally installed LLM models and their quantizations. The goal is to measure and
 
 ### General
 
-- Compatible with Python 3.10+
+- Compatible with Python 3.11+
 - Use logging instead of print() for important events
 
 ### Project-Specific

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
 
       - name: Install system dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@v6
 
       # prepare Python environment for later checks
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       # ensure main python script compiles
       - name: Python syntax check (main script)
@@ -77,10 +77,10 @@ jobs:
         uses: actions/checkout@v6
 
       # set up same Python version
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       # install system dependencies for PyGObject (optional)
       - name: Install system dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -58,7 +58,7 @@ jobs:
         if: steps.snyk_token.outputs.configured == 'true'
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install system dependencies
         if: steps.snyk_token.outputs.configured == 'true'

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@
 load-plugins = pylint.extensions.docparams
 
 # Target runtime version for type analysis
-py-version = 3.10
+py-version = 3.11
 
 # Ignore patterns (test files and generated code)
 ignore-patterns = test_.*?\.py
@@ -26,7 +26,7 @@ disable=
     R0911,
     R0916,
     R1732,
-    # False positives in Codacy's bundled pylint (Python 3.10 code):
+    # False positives in Codacy's bundled pylint (Python 3.11 code):
     # E1101: Path inherits PurePath but has .exists/.mkdir etc.
     E1101,
     # E1136: list[str] / dict[...] generics valid since Python 3.9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thanks for contributing to LM-Studio-Bench.
 
 ## Quick Start
 
+Python 3.11 or newer is required.
+
 **1.** Fork and clone the repository.
 **2.** Create a virtual environment and install dependencies:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Automatic benchmarking tool for all locally installed LM Studio models. Systemat
 quantizations to measure and compare tokens-per-second performance.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Python 3.10+](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Platform](https://img.shields.io/badge/Platform-Linux-orange.svg)](https://www.linux.org/)
 [![LM Studio App v0.4.3+](https://img.shields.io/badge/LM_Studio_App-v0.4.3+-green.svg)](https://lmstudio.ai/download)
 [![llmster v0.0.3+](https://img.shields.io/badge/llmster-v0.0.3+-green.svg)](https://lmstudio.ai)
@@ -100,7 +100,7 @@ quantizations to measure and compare tokens-per-second performance.
 ## System Requirements
 
 - **OS**: Linux (primary), macOS (untested), Windows (untested)
-- **Python**: 3.10 or newer
+- **Python**: 3.11 or newer
 - **GPU**: ~12GB VRAM recommended (NVIDIA/AMD/Intel)
 - **Software**: [LM Studio](https://lmstudio.ai/) or
   [LM Studio (Headless)](https://lmstudio.ai/docs/developer/core/headless_llmster/) installed locally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@
 
 [project]
 name = "lm-studio-bench"
-# Version mirrors the VERSION file; bump both together.
+# Version mirrors VERSION after stripping any leading "v"; bump both
+# together.
 version = "0.2.0"
 requires-python = ">=3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 # PyProject Configuration for LM-Studio-Bench
 # See: https://peps.python.org/pep-0518/
 
+[project]
+name = "lm-studio-bench"
+# Version mirrors the VERSION file; bump both together.
+version = "0.2.0"
+requires-python = ">=3.11"
+
 [tool.isort]
 # Profile compatible with Black
 profile = "black"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,6 +27,5 @@ uvicorn[standard]>=0.24.0
 jinja2>=3.1.6
 distro>=1.8.0
 py-cpuinfo>=9.0.0
-scipy>=1.17.1; python_version >= "3.11"
-scipy>=1.11,<1.16; python_version < "3.11"
+scipy>=1.17.1
 pydantic>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ jinja2>=3.1.6
 httpx>=0.28,<0.29
 distro>=1.8.0
 py-cpuinfo>=9.0.0
-scipy>=1.17.1; python_version >= "3.11"
-scipy>=1.11,<1.16; python_version < "3.11"
+scipy>=1.17.1
 pydantic>=2.0.0
 PyGObject>=3.48,<3.50
 PyYAML>=6.0

--- a/scripts/Dockerfile.bench
+++ b/scripts/Dockerfile.bench
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/setup.sh
+++ b/setup.sh
@@ -735,6 +735,14 @@ check_python_requirements() {
         return 1
     fi
 
+    if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+        local detected_version
+        detected_version="$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null || echo unknown)"
+        log "ERROR" "Python 3.11 or newer required (detected: ${detected_version})."
+        log "INFO" "Install a newer Python (e.g. via your package manager, pyenv, or python.org)."
+        return 1
+    fi
+
     if [[ ! -f "${PROJECT_ROOT}/requirements.txt" ]]; then
         log "WARN" "requirements.txt not found."
         return 0

--- a/tests/test_user_paths.py
+++ b/tests/test_user_paths.py
@@ -20,6 +20,7 @@ class TestGetUserConfigDir:
     def test_falls_back_to_home_config(self, tmp_path: Path, monkeypatch):
         """Falls back to ~/.config/lm-studio-bench when XDG_CONFIG_HOME unset."""
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.delenv("SNAP_REAL_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         import importlib
 
@@ -45,6 +46,7 @@ class TestGetUserConfigDir:
             self, tmp_path: Path, monkeypatch):
         """Relative traversal values fall back to default config path."""
         monkeypatch.setenv("XDG_CONFIG_HOME", "../etc")
+        monkeypatch.delenv("SNAP_REAL_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         import importlib
 
@@ -71,6 +73,7 @@ class TestGetUserDataDir:
     def test_falls_back_to_home_local_share(self, tmp_path: Path, monkeypatch):
         """Falls back to ~/.local/share/lm-studio-bench when unset."""
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.delenv("SNAP_REAL_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         import importlib
 
@@ -97,6 +100,7 @@ class TestGetUserDataDir:
     ):
         """Relative traversal values fall back to default data path."""
         monkeypatch.setenv("XDG_DATA_HOME", "../../var")
+        monkeypatch.delenv("SNAP_REAL_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         import importlib
 


### PR DESCRIPTION
This pull request updates the project to require Python 3.11 or newer, removing support for Python 3.10 and adding preliminary support for Python 3.13 in CI. It updates documentation, configuration, and CI/CD workflows to reflect this new requirement, and improves version checks in setup scripts. Minor test improvements are also included.

**Python Version Requirement Updates:**

* Changed the minimum required Python version to 3.11 across documentation (`README.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`) and badges. (F9dbbd49L4R4, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R103) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L17-R17) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R7-R8)
* Updated the `pyproject.toml` to specify `requires-python = ">=3.11"` and added a `[project]` section.
* Updated `.pylintrc` to target Python 3.11 for type analysis and comments. [[1]](diffhunk://#diff-ba293004ae8f18975051e825bd8d5c70137a8b5d42d16e0f7c9354aa634c446cL9-R9) [[2]](diffhunk://#diff-ba293004ae8f18975051e825bd8d5c70137a8b5d42d16e0f7c9354aa634c446cL29-R29)
* Updated `setup.sh` to enforce Python 3.11 or newer, with improved error messaging.

**Continuous Integration and Docker:**

* Updated all GitHub Actions workflows to use Python 3.11 (and 3.12/3.13 where applicable), removing Python 3.10 from the matrix. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL24-R27) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL80-R83) [[3]](diffhunk://#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7L29-R29) [[4]](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L17-R17) [[5]](diffhunk://#diff-d445f9c3137cb4ffc44034bee1b60cd945a8d9d58f417ee88c41996d72f79880L61-R61)
* Updated the Dockerfile to use `python:3.11-slim` as the base image.

**Dependency Management:**

* Simplified `requirements-dev.txt` by removing Python-version-specific `scipy` constraints, now requiring `scipy>=1.17.1` for all supported versions.

**Testing Improvements:**

* Updated tests in `tests/test_user_paths.py` to unset `SNAP_REAL_HOME` for more robust environment isolation. [[1]](diffhunk://#diff-5b2cd5097738b29cc3763734e5dde39a8aef9a9bd6195a286a1d6dde328187f9R23) [[2]](diffhunk://#diff-5b2cd5097738b29cc3763734e5dde39a8aef9a9bd6195a286a1d6dde328187f9R49) [[3]](diffhunk://#diff-5b2cd5097738b29cc3763734e5dde39a8aef9a9bd6195a286a1d6dde328187f9R76) [[4]](diffhunk://#diff-5b2cd5097738b29cc3763734e5dde39a8aef9a9bd6195a286a1d6dde328187f9R103)