### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: dev
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: pip
+    directory: "/"
+    target-branch: dev
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: "/"
+    target-branch: dev
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,3 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-
-  - package-ecosystem: npm
-    directory: "/"
-    target-branch: dev
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5


### PR DESCRIPTION
This pull request adds a new `.github/dependabot.yml` configuration file to enable automated dependency updates for GitHub Actions, Python (`pip`), and Node.js (`npm`) packages. All updates are set to target the `dev` branch on a weekly schedule, with limits on the number of open pull requests per ecosystem.

Dependency update automation:

* Added `.github/dependabot.yml` to configure Dependabot for:
  - GitHub Actions (limit 10 open PRs, weekly updates to `dev`)
  - Python packages via `pip` (limit 5 open PRs, weekly updates to `dev`)
  - Node.js packages via `npm` (limit 5 open PRs, weekly updates to `dev`)