### PR TITLE
feat: add macOS support

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -20,6 +20,8 @@ permissions:
 
 jobs:
   codacy-security-scan:
+    # CODACY_PROJECT_TOKEN only exists in the upstream repository.
+    if: ${{ github.repository == 'Ajimaru/LM-Studio-Bench' }}
     permissions:
       contents: read # for actions/checkout to fetch code
       actions: read # only required for a private repository

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -27,6 +27,9 @@ concurrency:
 jobs:
   # Build job
   build:
+    # Publishes the upstream documentation site. Forks need their own
+    # GitHub Pages setup, so this is skipped rather than failing on push.
+    if: ${{ github.repository == 'Ajimaru/LM-Studio-Bench' }}
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: 0.4.36

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -34,6 +34,9 @@ permissions:
 
 jobs:
   snyk:
+    # SNYK_TOKEN only exists in the upstream repository, so this job is
+    # skipped in forks instead of failing on every push.
+    if: ${{ github.repository == 'Ajimaru/LM-Studio-Bench' }}
     permissions:
       contents: read
       security-events: write

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ quantizations to measure and compare tokens-per-second performance.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Platform](https://img.shields.io/badge/Platform-Linux-orange.svg)](https://www.linux.org/)
+[![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20macOS-orange.svg)](https://www.linux.org/)
 [![LM Studio App v0.4.3+](https://img.shields.io/badge/LM_Studio_App-v0.4.3+-green.svg)](https://lmstudio.ai/download)
 [![llmster v0.0.3+](https://img.shields.io/badge/llmster-v0.0.3+-green.svg)](https://lmstudio.ai)
 [![Release](https://img.shields.io/github/v/release/Ajimaru/LM-Studio-Bench)](https://github.com/Ajimaru/LM-Studio-Bench/releases/latest)
@@ -99,9 +99,36 @@ quantizations to measure and compare tokens-per-second performance.
 
 ## System Requirements
 
-- **OS**: Linux (primary), macOS (untested), Windows (untested)
+- **OS**: Linux (primary), macOS 11+ (supported), Windows (untested)
 - **Python**: 3.10 or newer
-- **GPU**: ~12GB VRAM recommended (NVIDIA/AMD/Intel)
+- **GPU**: ~12GB VRAM recommended (NVIDIA/AMD/Intel), or an Apple Silicon
+  Mac with ~16GB+ unified memory
+
+### macOS notes
+
+macOS is supported for benchmarking, the CLI and the web dashboard. Two
+platform differences are worth knowing:
+
+- **No system tray.** The tray is built on GTK/AppIndicator, which is
+  Linux-only. On macOS it is skipped with a one-line notice; everything else
+  runs normally. `PyGObject` is therefore not installed on macOS.
+- **GPU temperature and power need `macmon`** (optional). macOS exposes
+  these only through `sudo powermetrics`; [macmon](https://github.com/vladkens/macmon)
+  reads the same counters without root, so unattended runs can record them:
+
+  ```bash
+  brew install macmon
+  ```
+
+  Without macmon, `temp_celsius_*` and `power_watts_*` stay empty and the
+  `--max-temp` / `--max-power` guardrails have nothing to compare against.
+  Everything else still works. GPU model, core count, Metal support level
+  and unified-memory usage come from `system_profiler` and `ioreg` and need
+  no extra tooling.
+
+Apple Silicon reports one unified memory pool, so VRAM and system RAM are the
+same memory. The dashboard shows it as a single total rather than adding
+VRAM and GTT together.
 - **Software**: [LM Studio](https://lmstudio.ai/) or
   [LM Studio (Headless)](https://lmstudio.ai/docs/developer/core/headless_llmster/) installed locally
 
@@ -152,13 +179,18 @@ cd LM-Studio-Bench
 ./setup.sh
 ```
 
-The setup script checks and prepares:
+The setup script runs on both Linux and macOS and checks:
 
-- Linux system dependencies (package-manager aware)
-- GPU tooling (`nvidia-smi`, `rocm-smi`, `intel_gpu_top` when available)
+- System dependencies (package-manager aware: apt/dnf/pacman/zypper/apk on
+  Linux, Homebrew on macOS)
+- GPU tooling — Linux: `nvidia-smi`, `rocm-smi`, `intel_gpu_top` when
+  available; macOS: `system_profiler` (GPU model, cores, Metal, unified
+  memory)
 - LM Studio / llmster availability
 - Python virtual environment (`.venv`)
 - Python dependencies from `requirements.txt`
+
+On macOS the GTK/PyGObject checks are skipped, since the tray is Linux-only.
 
 #### 3. Activate the virtual environment
 
@@ -172,7 +204,7 @@ source .venv/bin/activate
 
 #### 4. Manual fallback (if you skip `setup.sh`)
 
-Install system dependencies (Linux, tray support):
+Install system dependencies (Linux only — these provide tray support):
 
 ```bash
 # Ubuntu/Debian
@@ -185,13 +217,19 @@ sudo dnf install python3-devel gobject-introspection-devel cairo-devel pkg-confi
 sudo pacman -S python gobject-introspection cairo pkgconf
 ```
 
-Install Python dependencies:
+On macOS no system libraries are required. Python 3.10+ is enough; install
+it with `brew install python@3.12` if the system Python is too old.
+
+Install Python dependencies (same on Linux and macOS):
 
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
+
+`PyGObject` and `distro` carry a `sys_platform == "linux"` marker, so pip
+skips them on macOS and the install needs no GTK toolchain.
 
 #### 5. Check LM Studio CLI
 

--- a/cli/benchmark.py
+++ b/cli/benchmark.py
@@ -33,6 +33,7 @@ from core.client import LMStudioRESTClient
 from core.config import BASE_DEFAULT_CONFIG, DEFAULT_CONFIG
 from core.logging_utils import install_level_icons
 from core.paths import USER_LOGS_DIR, USER_RESULTS_DIR, format_path_for_logs
+from core.platform_info import IS_MACOS, get_os_name_version
 from core.presets import PresetManager
 from tools.hardware_monitor import GPUMonitor, HardwareMonitor
 
@@ -1601,6 +1602,38 @@ class LMStudioServerManager:
         return True
 
 
+def extract_quantization_name(value: Any) -> Optional[str]:
+    """Normalize a quantization field into a plain name string.
+
+    LM Studio changed this field's shape. Older builds returned a plain
+    string (and encoded the quantization in the model key as
+    ``model@Q4_K_M``); newer builds return an object instead:
+
+    - ``lms ls --json``      -> ``{"name": "Q4_K_M", "bits": 4}``
+    - REST ``/api/v1/models`` -> ``{"name": "Q4_K_M", "bits_per_weight": 4}``
+
+    Args:
+        value: Raw quantization value from the CLI or REST payload.
+
+    Returns:
+        The quantization name (e.g. ``Q4_K_M``, ``4bit``), or None when it
+        cannot be determined.
+    """
+    if isinstance(value, str):
+        return value.strip() or None
+
+    if isinstance(value, dict):
+        name = value.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+
+        bits = value.get("bits", value.get("bits_per_weight"))
+        if isinstance(bits, (int, float)):
+            return f"{int(bits)}bit"
+
+    return None
+
+
 class ModelDiscovery:
     """Finds all locally installed models"""
 
@@ -1632,6 +1665,9 @@ class ModelDiscovery:
                                 "architecture": model_data.get(
                                     "architecture", "unknown"
                                 ),
+                                "quantization": extract_quantization_name(
+                                    model_data.get("quantization")
+                                ),
                                 "params_size": model_data.get(
                                     "paramsString", "unknown"
                                 ),
@@ -1662,6 +1698,7 @@ class ModelDiscovery:
             base_model,
             {
                 "architecture": "unknown",
+                "quantization": None,
                 "params_size": "unknown",
                 "max_context_length": 0,
                 "model_size_gb": 0.0,
@@ -1857,6 +1894,8 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def get_nvidia_driver_version() -> Optional[str]:
         """Retrieves NVIDIA Driver version"""
+        if IS_MACOS:
+            return None
         try:
             result = subprocess.run(
                 ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
@@ -1875,6 +1914,8 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def get_rocm_driver_version() -> Optional[str]:
         """Retrieves AMD ROCm/Driver version"""
+        if IS_MACOS:
+            return None
         try:
             rocm_paths = ["/usr/bin/rocm-smi", "/usr/local/bin/rocm-smi"]
             rocm_paths.extend(glob.glob("/opt/rocm-*/bin/rocm-smi"))
@@ -1945,6 +1986,8 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def get_intel_driver_version() -> Optional[str]:
         """Retrieves Intel GPU Driver version"""
+        if IS_MACOS:
+            return None
         try:
             result = subprocess.run(
                 ["intel_gpu_top", "--help"],
@@ -1984,9 +2027,9 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
                     os_version = platform.release()
                     return os_name, os_version
             else:
-                os_name = os_system
-                os_version = platform.release()
-                return os_name, os_version
+                # macOS reports "macOS Tahoe"/"26.6" instead of
+                # "Darwin"/"25.6.0"; other systems keep platform values.
+                return get_os_name_version()
         except OSError:
             logger.debug("OS info not available")
         return None, None
@@ -2529,17 +2572,23 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
             except (subprocess.SubprocessError, OSError) as e:
                 logger.warning("⚠️ Error unloading all models: %s", e)
 
+        metadata = ModelDiscovery.get_model_metadata(model_key)
+        model_size_gb = metadata.get("model_size_gb", 0)
+
+        # Older LM Studio encoded the quantization in the model key
+        # ("model@Q4_K_M"). Newer builds use a flat key and report the
+        # quantization as its own field, so fall back to the metadata.
         if "@" in model_key:
             model_name, quantization = model_key.split("@", 1)
         else:
             model_name = model_key
-            quantization = "unknown"
-
-        metadata = ModelDiscovery.get_model_metadata(model_key)
-        model_size_gb = metadata.get("model_size_gb", 0)
+            quantization = (
+                extract_quantization_name(metadata.get("quantization"))
+                or "unknown"
+            )
 
         smart_offload_levels = self._get_smart_offload_levels(model_key, model_size_gb)
-        logger.info("🎯 Intelligente Offload-Levels: %s", smart_offload_levels)
+        logger.info("🎯 Smart offload levels: %s", smart_offload_levels)
 
         used_offload = smart_offload_levels[0] if smart_offload_levels else 1.0
         instance_id: Optional[str] = None
@@ -3689,7 +3738,7 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
                 break
 
         if vram_info:
-            recommendations.append("🎯 VRAM-Empfehlungen:")
+            recommendations.append("🎯 VRAM recommendations:")
             recommendations.extend(vram_info[:3])
 
         return recommendations
@@ -3776,7 +3825,7 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
 
             fig.update_layout(
                 title="Performance trends over time",
-                xaxis_title="Datum",
+                xaxis_title="Date",
                 yaxis_title="Tokens/s",
                 hovermode="x unified",
                 height=600,
@@ -4305,7 +4354,7 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
             if comp_data:
                 elements.append(
                     Paragraph(
-                        "Quantisierungs-Vergleich (Q4 vs Q5 vs Q6)", heading_style
+                        "Quantization Comparison (Q4 vs Q5 vs Q6)", heading_style
                     )
                 )
 
@@ -4710,7 +4759,7 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
                 powers_avg = [r.power_watts_avg for r in results if r.power_watts_avg]
 
                 profile_summary = [
-                    ["Metrik", "Min", "Max", "Durchschnitt"],
+                    ["Metric", "Min", "Max", "Average"],
                 ]
 
                 if temps_avg:
@@ -5756,7 +5805,7 @@ Examples:
         dest="min_p_sampling",
         type=float,
         default=None,
-        help="Override: Min-P (Minimum probability threshold, z.B. 0.05)",
+        help="Override: Min-P (Minimum probability threshold, e.g. 0.05)",
     )
     parser.add_argument(
         "--repeat-penalty",

--- a/cli/main.py
+++ b/cli/main.py
@@ -24,6 +24,7 @@ from agents.runner import BenchmarkRunner
 from cli.reporting import HTMLReporter, sanitize_report_name
 from core.logging_utils import install_level_icons
 from core.paths import USER_RESULTS_DIR
+from core.platform_info import IS_MACOS, get_os_name_version
 from tools.hardware_monitor import GPUMonitor, HardwareMonitor
 
 try:
@@ -161,7 +162,20 @@ def _get_lmstudio_version() -> Optional[str]:
 
 
 def _get_driver_versions() -> dict[str, Optional[str]]:
-    """Collect GPU driver versions across NVIDIA/AMD/Intel tools."""
+    """Collect GPU driver versions across NVIDIA/AMD/Intel tools.
+
+    macOS ships none of these vendor tools, so all three fields stay empty
+    there rather than being filled with an unrelated value. The macOS GPU is
+    identified through ``gpu_type``/``gpu_model`` and the Metal support level
+    shown on the dashboard.
+    """
+    if IS_MACOS:
+        return {
+            "nvidia_driver_version": None,
+            "rocm_driver_version": None,
+            "intel_driver_version": None,
+        }
+
     nvidia = _run_command(
         ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"]
     )
@@ -187,7 +201,7 @@ def _get_os_info() -> tuple[Optional[str], Optional[str]]:
     try:
         if platform.system() == "Linux" and DISTRO is not None:
             return DISTRO.name(), DISTRO.version()
-        return platform.system(), platform.release()
+        return get_os_name_version()
     except OSError:
         return None, None
 

--- a/core/platform_info.py
+++ b/core/platform_info.py
@@ -1,0 +1,291 @@
+"""Cross-platform OS and GPU detection helpers.
+
+Centralizes the platform-specific probes used by the benchmark CLI, the web
+dashboard and the hardware monitor so that Linux, macOS and other systems are
+handled in one place instead of being spread across call sites.
+
+On macOS the equivalents of the Linux tooling are:
+
+===================  ==========================================
+Linux                macOS
+===================  ==========================================
+``lspci``            ``system_profiler SPDisplaysDataType``
+``nvidia-smi``       ``ioreg -c IOAccelerator`` (Apple Silicon)
+``/sys/class/drm``   ``ioreg`` / ``sysctl``
+``xdg-open``         ``open``
+``lm-sensors``       ``powermetrics`` (requires root)
+===================  ==========================================
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import platform
+import re
+import subprocess
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+IS_MACOS = platform.system() == "Darwin"
+IS_LINUX = platform.system() == "Linux"
+IS_WINDOWS = platform.system() == "Windows"
+
+_SUBPROCESS_TIMEOUT = 5
+
+# Marketing names keyed by the major macOS release. ``platform.mac_ver``
+# reports the product version, so only the leading component is looked up.
+_MACOS_RELEASE_NAMES = {
+    "26": "Tahoe",
+    "15": "Sequoia",
+    "14": "Sonoma",
+    "13": "Ventura",
+    "12": "Monterey",
+    "11": "Big Sur",
+    "10.15": "Catalina",
+}
+
+_IOREG_STATS_RE = re.compile(r'"PerformanceStatistics"\s*=\s*\{(?P<body>[^}]*)\}')
+
+
+def _run_text_command(command: List[str]) -> Optional[str]:
+    """Run a command and return stdout, or None when it is unavailable.
+
+    Args:
+        command: Argument vector to execute.
+
+    Returns:
+        Captured stdout on success, otherwise None.
+    """
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as error:
+        logger.debug("Command %s unavailable: %s", command[0], error)
+        return None
+
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout
+
+
+def get_macos_name_version() -> Tuple[str, str]:
+    """Return the macOS product name and version.
+
+    Returns:
+        Tuple such as ``("macOS Tahoe", "26.6")``. The marketing name is
+        appended only when the release is known.
+    """
+    product_version = platform.mac_ver()[0] or platform.release()
+
+    major = product_version.split(".", maxsplit=1)[0]
+    release_name = _MACOS_RELEASE_NAMES.get(major)
+    if release_name is None and product_version.startswith("10."):
+        release_name = _MACOS_RELEASE_NAMES.get(
+            ".".join(product_version.split(".")[:2])
+        )
+
+    name = f"macOS {release_name}" if release_name else "macOS"
+    return name, product_version
+
+
+def get_os_name_version() -> Tuple[Optional[str], Optional[str]]:
+    """Return a human readable OS name and version for any platform.
+
+    Linux distributions are resolved through ``distro`` when installed;
+    macOS uses ``platform.mac_ver``. Everything else falls back to the
+    generic ``platform`` values.
+    """
+    system = platform.system()
+
+    if system == "Darwin":
+        return get_macos_name_version()
+
+    if system == "Linux":
+        try:
+            import distro  # pylint: disable=import-outside-toplevel
+
+            distro_name = distro.name()
+            if distro_name:
+                return distro_name, distro.version()
+        except (ImportError, OSError):
+            logger.debug("distro module unavailable, using platform fallback")
+
+    return system, platform.release()
+
+
+def get_open_url_command() -> Optional[str]:
+    """Return the platform command that opens a URL in the default browser."""
+    if IS_MACOS:
+        return "open"
+    if IS_LINUX:
+        return "xdg-open"
+    if IS_WINDOWS:
+        return "start"
+    return None
+
+
+def detect_apple_gpu() -> Optional[Dict[str, Any]]:
+    """Detect the integrated Apple Silicon / Apple-vendored GPU.
+
+    Uses ``system_profiler SPDisplaysDataType`` which is present on every
+    macOS install and needs no elevated privileges.
+
+    Returns:
+        Mapping with ``model``, ``cores``, ``metal_family`` and ``vendor``,
+        or None when no GPU is reported.
+    """
+    if not IS_MACOS:
+        return None
+
+    output = _run_text_command(
+        ["system_profiler", "-json", "SPDisplaysDataType"]
+    )
+    if not output:
+        return None
+
+    try:
+        displays = json.loads(output).get("SPDisplaysDataType", [])
+    except (json.JSONDecodeError, AttributeError) as error:
+        logger.debug("Could not parse system_profiler output: %s", error)
+        return None
+
+    for entry in displays:
+        if not isinstance(entry, dict):
+            continue
+
+        model = entry.get("sppci_model") or entry.get("_name")
+        if not model:
+            continue
+
+        cores_raw = entry.get("sppci_cores")
+        try:
+            cores = int(cores_raw) if cores_raw is not None else None
+        except (TypeError, ValueError):
+            cores = None
+
+        metal_family = entry.get("spdisplays_mtlgpufamilysupport")
+        if isinstance(metal_family, str):
+            metal_family = metal_family.replace("spdisplays_", "")
+
+        vendor_raw = entry.get("spdisplays_vendor", "")
+        vendor = str(vendor_raw).replace("sppci_vendor_", "") or "Unknown"
+
+        return {
+            "model": model,
+            "cores": cores,
+            "metal_family": metal_family,
+            "vendor": vendor,
+        }
+
+    return None
+
+
+def read_apple_gpu_stats() -> Dict[str, Optional[float]]:
+    """Read live Apple GPU statistics via ``ioreg``.
+
+    Apple Silicon uses unified memory, so "VRAM in use" is reported as the
+    driver's in-use system memory. Temperature and power draw are only
+    exposed by ``powermetrics``, which requires root, and are therefore not
+    included here.
+
+    Returns:
+        Mapping with ``utilization_percent`` and ``vram_used_gb``. Values are
+        None when they cannot be read.
+    """
+    stats: Dict[str, Optional[float]] = {
+        "utilization_percent": None,
+        "vram_used_gb": None,
+    }
+
+    if not IS_MACOS:
+        return stats
+
+    output = _run_text_command(
+        ["ioreg", "-r", "-d", "1", "-w", "0", "-c", "IOAccelerator"]
+    )
+    if not output:
+        return stats
+
+    match = _IOREG_STATS_RE.search(output)
+    if not match:
+        return stats
+
+    body = match.group("body")
+
+    utilization = re.search(r'"Device Utilization %"\s*=\s*(\d+)', body)
+    if utilization:
+        stats["utilization_percent"] = float(utilization.group(1))
+
+    in_use = re.search(r'"In use system memory"\s*=\s*(\d+)', body)
+    if in_use:
+        stats["vram_used_gb"] = float(in_use.group(1)) / (1024**3)
+
+    return stats
+
+
+def get_apple_unified_memory_gb() -> Optional[float]:
+    """Return total unified memory in GB, which doubles as usable VRAM."""
+    if not IS_MACOS:
+        return None
+
+    output = _run_text_command(["sysctl", "-n", "hw.memsize"])
+    if not output:
+        return None
+
+    try:
+        return round(int(output.strip()) / (1024**3), 2)
+    except ValueError:
+        return None
+
+
+def get_metal_driver_version() -> Optional[str]:
+    """Return the Metal support level as the macOS GPU "driver version".
+
+    macOS exposes no user-facing GPU driver version; the Metal family
+    supported by the GPU plus the OS build is the closest equivalent.
+    """
+    if not IS_MACOS:
+        return None
+
+    gpu_info = detect_apple_gpu()
+    metal_family = gpu_info.get("metal_family") if gpu_info else None
+
+    build = _run_text_command(["sw_vers", "-buildVersion"])
+    build_version = build.strip() if build else platform.release()
+
+    if metal_family:
+        return f"{metal_family} (macOS build {build_version})"
+    return f"macOS build {build_version}"
+
+
+def get_apple_chip_name() -> Optional[str]:
+    """Return the Apple Silicon chip name (e.g. ``Apple M4 Max``)."""
+    if not IS_MACOS:
+        return None
+
+    output = _run_text_command(["sysctl", "-n", "machdep.cpu.brand_string"])
+    if output and output.strip():
+        return output.strip()
+    return None
+
+
+__all__ = [
+    "IS_LINUX",
+    "IS_MACOS",
+    "IS_WINDOWS",
+    "detect_apple_gpu",
+    "get_apple_chip_name",
+    "get_apple_unified_memory_gb",
+    "get_macos_name_version",
+    "get_metal_driver_version",
+    "get_open_url_command",
+    "get_os_name_version",
+    "read_apple_gpu_stats",
+]

--- a/core/tray.py
+++ b/core/tray.py
@@ -23,6 +23,7 @@ from urllib import request as urllib_request
 import webbrowser
 
 from core.paths import USER_LOGS_DIR
+from core.platform_info import IS_LINUX, IS_MACOS
 from core.version import fetch_latest_release
 
 _LATEST_RELEASE_LOCK = threading.Lock()
@@ -92,7 +93,13 @@ def _prepend_env_paths(var_name: str, paths: list[str]) -> None:
 
 
 def _bootstrap_gi_runtime_paths() -> None:
-    """Ensure GI typelibs and shared libs are discoverable in AppImage mode."""
+    """Ensure GI typelibs and shared libs are discoverable in AppImage mode.
+
+    AppImage is a Linux packaging format, so this is a no-op elsewhere.
+    """
+    if not IS_LINUX:
+        return
+
     project_root = Path(__file__).resolve().parent.parent
     appdir_candidate = project_root.parents[2]
 
@@ -163,6 +170,26 @@ else:
 LOGGER = logging.getLogger("tray")
 _TRAY_STATE: dict[str, Optional[threading.Thread]] = {"thread": None}
 _WEBAPP_URL_RE = re.compile(r"Dashboard available at (http://localhost:\d+)")
+
+
+def tray_unavailable_reason() -> Optional[str]:
+    """Explain why the tray cannot start, or return None when it can.
+
+    The tray is built on GTK/AppIndicator, which is packaged for Linux
+    desktops only. Callers use this to report a clear message instead of a
+    GTK import traceback.
+    """
+    if IMPORT_ERROR is None:
+        return None
+
+    if IS_MACOS:
+        return (
+            "The GTK system tray is Linux-only and is not available on "
+            "macOS. Benchmarks, the CLI and the web dashboard are "
+            "unaffected."
+        )
+
+    return f"Tray dependencies unavailable: {IMPORT_ERROR}"
 
 
 def _normalize_dashboard_url(dashboard_url: str) -> str:
@@ -1258,8 +1285,9 @@ def start_tray(dashboard_url: str, debug: bool = False) -> bool:
     log_file = _setup_logger(debug=debug)
     LOGGER.info("Tray log file: %s", log_file)
 
-    if IMPORT_ERROR is not None:
-        LOGGER.warning("Tray dependencies unavailable: %s", IMPORT_ERROR)
+    unavailable_reason = tray_unavailable_reason()
+    if unavailable_reason is not None:
+        LOGGER.warning("%s", unavailable_reason)
         return False
 
     current_thread = _TRAY_STATE["thread"]
@@ -1322,9 +1350,9 @@ def main() -> int:
     log_file = _setup_logger(debug=args.debug)
     LOGGER.info("Tray standalone start, log: %s", log_file)
 
-    if IMPORT_ERROR is not None:
-        msg = f"Cannot start tray, missing dependencies: {IMPORT_ERROR}"
-        LOGGER.error(msg)
+    unavailable_reason = tray_unavailable_reason()
+    if unavailable_reason is not None:
+        LOGGER.error("Cannot start tray: %s", unavailable_reason)
         return 1
 
     try:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -42,6 +42,7 @@ pip install -r requirements.txt
 `~/.local/share/lm-studio-bench/logs/webapp_*.log` and
 `~/.local/share/lm-studio-bench/logs/benchmark_*.log`
 ✅ Linux tray control with dynamic status icon and quick actions
+(skipped on macOS, see below)
 
 **Dashboard Features:**
 
@@ -72,6 +73,29 @@ with the web app.
   - Pause/Stop enabled only in running/paused states
 - **Auto refresh**: status and controls refresh every 3 seconds
 - **Quit behavior**: tray `Quit` triggers graceful full shutdown
+
+### macOS
+
+The tray is GTK/AppIndicator based and is therefore Linux-only. On macOS
+`run.py` prints a one-line notice and continues; benchmarks, the CLI and the
+web dashboard all work normally. Use the dashboard in the browser for the
+Start/Pause/Stop controls the tray provides on Linux.
+
+GPU detection uses `system_profiler` and `ioreg`, so on Apple Silicon you get
+the chip name, GPU core count, Metal support level and unified-memory usage.
+
+For GPU temperature and power draw, install the optional
+[macmon](https://github.com/vladkens/macmon):
+
+```bash
+brew install macmon
+```
+
+macOS normally exposes those counters only via `sudo powermetrics`; macmon
+reads them without root, so `--enable-profiling` can record them in an
+unattended run and the `--max-temp` / `--max-power` limits become usable.
+When macmon is absent those two metrics stay empty and everything else runs
+unchanged.
 
 ### Network Access
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -3,4 +3,5 @@
 
 # System tray integration (Linux/X11)
 # Requires system libraries: libgirepository1.0, libcairo2, libcairo2-dev, gobject-introspection
-PyGObject>=3.48,<3.50
+# Not available on macOS: the tray is skipped there, everything else still runs.
+PyGObject>=3.48,<3.50; sys_platform == "linux"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,11 @@ fastapi>=0.109.0
 uvicorn[standard]>=0.24.0
 jinja2>=3.1.6
 httpx>=0.25.0
-distro>=1.8.0
+distro>=1.8.0; sys_platform == "linux"
 py-cpuinfo>=9.0.0
 scipy>=1.11.0
 pydantic>=2.0.0
-PyGObject>=3.48,<3.50
+# GTK system tray, Linux only. PyGObject needs gobject-introspection and
+# cairo development headers that macOS does not ship.
+PyGObject>=3.48,<3.50; sys_platform == "linux"
 PyYAML>=6.0

--- a/run.py
+++ b/run.py
@@ -18,6 +18,7 @@ Examples:
 """
 
 from datetime import datetime
+import importlib.util
 import os
 from pathlib import Path
 import re
@@ -30,6 +31,7 @@ import time
 from typing import TextIO
 
 from core.paths import USER_LOGS_DIR, format_path_for_logs
+from core.platform_info import IS_LINUX, IS_MACOS
 
 project_root = Path(__file__).parent
 os.chdir(project_root)
@@ -110,12 +112,20 @@ def _build_subprocess_env() -> dict[str, str]:
     env = os.environ.copy()
     env.pop("LD_LIBRARY_PATH", None)
     env.pop("LD_PRELOAD", None)
+    # macOS equivalents of LD_LIBRARY_PATH/LD_PRELOAD.
+    env.pop("DYLD_LIBRARY_PATH", None)
+    env.pop("DYLD_INSERT_LIBRARIES", None)
+    env.pop("DYLD_FRAMEWORK_PATH", None)
     root_dir = str(project_root)
     pythonpath_entries = [root_dir]
     existing_path = env.get("PYTHONPATH", "")
     if existing_path:
         pythonpath_entries.append(existing_path)
     env["PYTHONPATH"] = ":".join(pythonpath_entries)
+
+    # AppImage/GI bootstrapping is Linux-only packaging.
+    if not IS_LINUX:
+        return env
 
     appdir_candidate = project_root.parents[2]
     app_lib_dir = appdir_candidate / "usr" / "lib"
@@ -202,11 +212,45 @@ def _expand_short_flag_clusters(cli_args: list[str]) -> list[str]:
     return normalized
 
 
+def _tray_skip_reason() -> str | None:
+    """Return why the GTK tray cannot start here, or None if it can.
+
+    The tray relies on PyGObject/GTK, which is packaged for Linux desktops
+    only. On other platforms the tray is skipped rather than launched and
+    left to fail, so the dashboard and CLI output stays clean.
+
+    On Linux the tray is always attempted: ``_start_tray_process`` tries
+    several interpreters, and a system Python may provide ``gi`` even when
+    the project virtualenv does not.
+    """
+    if IS_LINUX:
+        return None
+
+    if importlib.util.find_spec("gi") is not None:
+        return None
+
+    if IS_MACOS:
+        return (
+            "ℹ️ System tray skipped: the GTK tray is Linux-only. "
+            "Benchmarks and the web dashboard are unaffected."
+        )
+    return (
+        "ℹ️ System tray skipped: PyGObject (gi) is not available on this "
+        "platform."
+    )
+
+
 def _start_tray_process(
     tray_dashboard_url: str,
     tray_debug_enabled: bool,
 ) -> subprocess.Popen | None:
     """Start tray app as background subprocess."""
+    skip_reason = _tray_skip_reason()
+    if skip_reason is not None:
+        # Flush so the notice keeps its place when stdout is a pipe or log.
+        print(skip_reason, flush=True)
+        return None
+
     tray_script = project_root / "core" / "tray.py"
     if not tray_script.exists():
         print(f"⚠️ Tray script not found: {format_path_for_logs(tray_script)}")

--- a/scripts/scan-all.sh
+++ b/scripts/scan-all.sh
@@ -10,6 +10,19 @@
 
 set -e
 
+# This script uses `readarray`, which needs bash >= 4. macOS still ships
+# bash 3.2 as /bin/bash, so re-exec under a newer bash when one is present.
+if [[ -z "${BASH_VERSINFO[0]:-}" || "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        if [[ -x "${candidate}" ]]; then
+            exec "${candidate}" "$0" "$@"
+        fi
+    done
+    echo "Error: this script needs bash >= 4 (found ${BASH_VERSION:-unknown})." >&2
+    echo "On macOS install a newer bash with: brew install bash" >&2
+    exit 1
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/setup.sh
+++ b/setup.sh
@@ -12,8 +12,10 @@ mkdir -p "${LOG_DIR}"
 touch "${LOG_FILE}"
 ln -sf "$(basename "${LOG_FILE}")" "${LOG_DIR}/setup_latest.log"
 
+# Fixed descriptor instead of `exec {LOG_FD}>>`: the varname-redirect form
+# needs bash >= 4.1, and macOS still ships bash 3.2 as /bin/bash.
 LOG_FD=3
-exec {LOG_FD}>> "${LOG_FILE}"
+exec 3>> "${LOG_FILE}"
 
 if [[ -t 1 ]]; then
     C_RESET="\033[0m"
@@ -37,6 +39,8 @@ PKG_UPDATE_CMD=""
 PKG_UPDATED="0"
 INTERACTIVE="1"
 DRY_RUN="0"
+# "linux" or "macos", set by ensure_supported_os().
+OS_FAMILY=""
 
 log() {
     local level="$1"
@@ -90,10 +94,10 @@ ask_yes_no() {
 
     if [[ "${INTERACTIVE}" == "0" ]]; then
         if [[ "${default_ans}" == "yes" ]]; then
-            log "INFO" "${prompt} [y/N]: ja (auto, --yes Mode)"
+            log "INFO" "${prompt} [y/N]: yes (auto, --yes mode)"
             return 0
         else
-            log "INFO" "${prompt} [y/N]: nein (auto, --yes Mode)"
+            log "INFO" "${prompt} [y/N]: no (auto, --yes mode)"
             return 1
         fi
     fi
@@ -150,15 +154,43 @@ NOTE:
 HELP
 }
 
-ensure_linux() {
-    if [[ "$(uname -s)" != "Linux" ]]; then
-        log "ERROR" "This setup script currently only supports Linux."
-        exit 1
-    fi
-    log "OK" "Linux detected: $(uname -sr)"
+ensure_supported_os() {
+    local kernel
+    kernel="$(uname -s)"
+
+    case "${kernel}" in
+        Linux)
+            OS_FAMILY="linux"
+            log "OK" "Linux detected: $(uname -sr)"
+            ;;
+        Darwin)
+            OS_FAMILY="macos"
+            local macos_version
+            macos_version="$(sw_vers -productVersion 2>/dev/null || echo "unknown")"
+            log "OK" "macOS detected: ${macos_version} ($(uname -m))"
+            ;;
+        *)
+            log "ERROR" "Unsupported OS '${kernel}'. Supported: Linux, macOS."
+            exit 1
+            ;;
+    esac
 }
 
 detect_pkg_manager() {
+    if [[ "${OS_FAMILY}" == "macos" ]]; then
+        if command -v brew >/dev/null 2>&1; then
+            PKG_MANAGER="brew"
+            PKG_INSTALL_CMD="brew install"
+            PKG_UPDATE_CMD="brew update"
+            log "OK" "Package manager detected: brew"
+            return 0
+        fi
+
+        log "WARN" "Homebrew not found. Optional packages cannot be installed."
+        log "INFO" "Install it from https://brew.sh, then re-run this script."
+        return 1
+    fi
+
     if command -v apt-get >/dev/null 2>&1; then
         PKG_MANAGER="apt"
         PKG_INSTALL_CMD="apt-get install -y"
@@ -195,6 +227,17 @@ run_pkg_update_once() {
         return 0
     fi
 
+    if [[ "${PKG_MANAGER}" == "brew" ]]; then
+        # Homebrew runs as the invoking user and refuses to run under sudo.
+        if [[ "${DRY_RUN}" == "1" ]]; then
+            log "INFO" "[DRY-RUN] Would execute: ${PKG_UPDATE_CMD}"
+        elif ! bash -lc "${PKG_UPDATE_CMD}"; then
+            log "WARN" "Could not update Homebrew. Proceeding anyway."
+        fi
+        PKG_UPDATED="1"
+        return 0
+    fi
+
     if [[ "${PKG_MANAGER}" == "apt" || "${PKG_MANAGER}" == "pacman" || \
           "${PKG_MANAGER}" == "zypper" || "${PKG_MANAGER}" == "apk" ]]; then
         if ! run_with_privileges "${PKG_UPDATE_CMD}"; then
@@ -212,6 +255,12 @@ run_with_privileges() {
     if [[ "${DRY_RUN}" == "1" ]]; then
         log "INFO" "[DRY-RUN] Would execute: ${cmd}"
         return 0
+    fi
+
+    # Homebrew must never run as root; it manages its own prefix.
+    if [[ "${PKG_MANAGER}" == "brew" ]]; then
+        bash -lc "${cmd}"
+        return $?
     fi
 
     if [[ "${EUID}" -eq 0 ]]; then
@@ -232,6 +281,27 @@ pkg_name_for_key() {
     local key="$1"
 
     case "${PKG_MANAGER}" in
+        brew)
+            # macOS ships no NVIDIA/AMD/Intel GPU tooling and no lspci,
+            # so those keys resolve to an empty package name.
+            case "${key}" in
+                python3) echo "python@3.12" ;;
+                pip3) echo "python@3.12" ;;
+                venv) echo "python@3.12" ;;
+                git) echo "git" ;;
+                curl) echo "curl" ;;
+                pkgconf) echo "pkg-config" ;;
+                python_dev) echo "python@3.12" ;;
+                gobj_dev) echo "gobject-introspection" ;;
+                cairo_dev) echo "cairo" ;;
+                pciutils) echo "" ;;
+                lm_sensors) echo "" ;;
+                intel_gpu_tools) echo "" ;;
+                rocm-smi) echo "" ;;
+                rocminfo) echo "" ;;
+                *) echo "" ;;
+            esac
+            ;;
         apt)
             case "${key}" in
                 python3) echo "python3" ;;
@@ -358,7 +428,7 @@ install_package_key() {
         return 0
     fi
 
-    log "ERROR" "Installation von '${package_name}' fehlgeschlagen."
+    log "ERROR" "Installation of '${package_name}' failed."
     return 1
 }
 
@@ -386,6 +456,12 @@ check_binary_dependency() {
 
 check_system_libs() {
     local missing_dev="0"
+
+    if [[ "${OS_FAMILY}" == "macos" ]]; then
+        log "INFO" "Skipping GTK/PyGObject checks: the system tray is Linux-only."
+        log "INFO" "Benchmarks, CLI and the web dashboard do not need GTK."
+        return 0
+    fi
 
     if command -v pkg-config >/dev/null 2>&1; then
         if ! pkg-config --exists gobject-introspection-1.0; then
@@ -441,14 +517,19 @@ open_download_link() {
         return 0
     fi
 
-    if command -v xdg-open >/dev/null 2>&1; then
-        if xdg-open "${url}" >/dev/null 2>&1; then
+    local opener="xdg-open"
+    if [[ "${OS_FAMILY}" == "macos" ]]; then
+        opener="open"
+    fi
+
+    if command -v "${opener}" >/dev/null 2>&1; then
+        if "${opener}" "${url}" >/dev/null 2>&1; then
             log "OK" "Browser opened for ${label}: ${url}"
         else
             log "WARN" "Could not open browser. Open URL manually: ${url}"
         fi
     else
-        log "WARN" "xdg-open not found. Open URL manually: ${url}"
+        log "WARN" "${opener} not found. Open URL manually: ${url}"
     fi
 }
 
@@ -471,14 +552,24 @@ check_lmstudio_stack() {
     else
         local search_paths=(
             "${HOME}/.lmstudio/llmster"
+            "${HOME}/.lmstudio/bin"
             "${HOME}/.local/share/lmstudio/llmster"
             "/opt/lmstudio/llmster"
             "/usr/local/lmstudio/llmster"
         )
 
+        if [[ "${OS_FAMILY}" == "macos" ]]; then
+            search_paths+=(
+                "/Applications/LM Studio.app/Contents/Resources"
+                "${HOME}/Applications/LM Studio.app/Contents/Resources"
+            )
+        fi
+
         for base_path in "${search_paths[@]}"; do
             if [[ -d "${base_path}" ]]; then
-                llmster_path=$(find "${base_path}" -name "llmster" -type f -executable 2>/dev/null | head -n1)
+                # -perm -u+x is POSIX and works with both GNU and BSD find;
+                # -executable is a GNU extension missing on macOS.
+                llmster_path=$(find "${base_path}" -name "llmster" -type f -perm -u+x 2>/dev/null | head -n1)
                 if [[ -n "${llmster_path}" && -x "${llmster_path}" ]]; then
                     has_llmster="1"
                     log "OK" "Headless CLI found: $(sanitize_path "${llmster_path}")"
@@ -532,6 +623,73 @@ check_optional_tool() {
     return 1
 }
 
+check_macos_gpu() {
+    local gpu_model=""
+    local gpu_cores=""
+    local metal_family=""
+
+    if ! command -v system_profiler >/dev/null 2>&1; then
+        log "WARN" "system_profiler missing. GPU detection not possible."
+        return 1
+    fi
+
+    gpu_model="$(system_profiler SPDisplaysDataType 2>/dev/null \
+        | awk -F': ' '/Chipset Model/ {print $2; exit}')"
+    gpu_cores="$(system_profiler SPDisplaysDataType 2>/dev/null \
+        | awk -F': ' '/Total Number of Cores/ {print $2; exit}')"
+    metal_family="$(system_profiler SPDisplaysDataType 2>/dev/null \
+        | awk -F': ' '/Metal/ {print $2; exit}')"
+
+    if [[ -z "${gpu_model}" ]]; then
+        log "WARN" "No GPU reported by system_profiler."
+        return 1
+    fi
+
+    if [[ -n "${gpu_cores}" ]]; then
+        log "OK" "GPU detected: ${gpu_model} (${gpu_cores} cores)"
+    else
+        log "OK" "GPU detected: ${gpu_model}"
+    fi
+
+    if [[ -n "${metal_family}" ]]; then
+        log "INFO" "Metal support: ${metal_family}"
+    fi
+
+    if [[ "$(uname -m)" == "arm64" ]]; then
+        local unified_gb
+        unified_gb="$(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1073741824 ))"
+        log "INFO" "Apple Silicon unified memory: ${unified_gb} GB (shared CPU/GPU)"
+        log "INFO" "LM Studio uses Metal acceleration; no extra driver needed."
+    fi
+
+    check_macmon
+    return 0
+}
+
+check_macmon() {
+    if command -v macmon >/dev/null 2>&1; then
+        log "OK" "macmon found: sudoless GPU temperature and power available."
+        return 0
+    fi
+
+    log "WARN" "macmon not found (optional)."
+    log "INFO" "Without it, GPU temperature and power need 'sudo powermetrics'"
+    log "INFO" "and stay empty in unprivileged runs (--max-temp/--max-power)."
+
+    if [[ "${PKG_MANAGER}" == "brew" ]] && ask_yes_no "Install macmon now?"; then
+        if [[ "${DRY_RUN}" == "1" ]]; then
+            log "INFO" "[DRY-RUN] Would execute: brew install macmon"
+        elif bash -lc "brew install macmon"; then
+            log "OK" "macmon installed."
+        else
+            log "WARN" "macmon installation failed."
+        fi
+    else
+        log "INFO" "Install later with: brew install macmon"
+    fi
+    return 0
+}
+
 check_gpu_and_monitoring() {
     local has_nvidia="0"
     local has_amd="0"
@@ -539,6 +697,11 @@ check_gpu_and_monitoring() {
     local gpu_lines=""
 
     section "GPU Detection & Monitoring"
+
+    if [[ "${OS_FAMILY}" == "macos" ]]; then
+        check_macos_gpu || true
+        return 0
+    fi
 
     if ! command -v lspci >/dev/null 2>&1; then
         log "WARN" "lspci missing. GPU detection will be limited."
@@ -577,7 +740,7 @@ check_gpu_and_monitoring() {
         log "INFO" "NVIDIA GPU detected."
         check_optional_tool \
             "nvidia-smi" \
-            "NVIDIA Treiber-Tool (nvidia-smi)" \
+            "NVIDIA driver tool (nvidia-smi)" \
             "" \
             "https://www.nvidia.com/Download/index.aspx" || true
     fi
@@ -607,7 +770,12 @@ check_gpu_and_monitoring() {
 }
 
 check_amd_drivers() {
-    section "AMD GPU Treiber & ROCm"
+    if [[ "${OS_FAMILY}" == "macos" ]]; then
+        log "INFO" "Skipping AMD/ROCm driver checks: not applicable on macOS."
+        return 0
+    fi
+
+    section "AMD GPU Drivers & ROCm"
     
     local gpu_device_id=""
     local gpu_sku=""
@@ -923,7 +1091,7 @@ main() {
         log "INFO" "Mode: Interactive"
     fi
 
-    ensure_linux
+    ensure_supported_os
     detect_pkg_manager || true
 
     section "Core Dependencies"

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -569,6 +569,52 @@ class TestLMStudioServerManager:
         assert result is True
 
 
+class TestExtractQuantizationName:
+    """Tests for extract_quantization_name().
+
+    LM Studio changed this field from a plain string to an object, and the
+    CLI and REST payloads spell the bit-count key differently.
+    """
+
+    def test_parses_lms_cli_object(self):
+        """`lms ls --json` returns {"name": ..., "bits": ...}."""
+        bm = _import_benchmark()
+        value = {"name": "Q4_K_M", "bits": 4}
+        assert bm.extract_quantization_name(value) == "Q4_K_M"
+
+    def test_parses_rest_object(self):
+        """REST /api/v1/models returns {"name": ..., "bits_per_weight": ...}."""
+        bm = _import_benchmark()
+        value = {"name": "Q4_K_M", "bits_per_weight": 4}
+        assert bm.extract_quantization_name(value) == "Q4_K_M"
+
+    def test_parses_mlx_style_name(self):
+        """MLX models report names such as '4bit'."""
+        bm = _import_benchmark()
+        assert bm.extract_quantization_name({"name": "4bit", "bits": 4}) == "4bit"
+
+    def test_accepts_legacy_plain_string(self):
+        """Older LM Studio returned a plain string."""
+        bm = _import_benchmark()
+        assert bm.extract_quantization_name("Q5_K_S") == "Q5_K_S"
+
+    def test_falls_back_to_bits_when_name_missing(self):
+        """A bits-only object degrades to a '<n>bit' label."""
+        bm = _import_benchmark()
+        assert bm.extract_quantization_name({"bits": 8}) == "8bit"
+        assert bm.extract_quantization_name({"bits_per_weight": 4}) == "4bit"
+
+    def test_returns_none_for_missing_or_blank(self):
+        """Absent or empty values yield None so callers can default."""
+        bm = _import_benchmark()
+        assert bm.extract_quantization_name(None) is None
+        assert bm.extract_quantization_name("") is None
+        assert bm.extract_quantization_name("   ") is None
+        assert bm.extract_quantization_name({}) is None
+        assert bm.extract_quantization_name({"name": ""}) is None
+        assert bm.extract_quantization_name(42) is None
+
+
 class TestModelDiscovery:
     """Tests for benchmark.ModelDiscovery."""
 
@@ -576,6 +622,40 @@ class TestModelDiscovery:
         """Clear metadata cache before each test."""
         bm = _import_benchmark()
         bm.ModelDiscovery._metadata_cache = {}
+
+    def test_metadata_cache_captures_nested_quantization(self):
+        """Quantization from newer `lms ls --json` reaches the cache."""
+        import json as _json
+        bm = _import_benchmark()
+        models_data = [
+            {
+                "type": "llm",
+                "modelKey": "thinkingcap-qwen3.6-27b",
+                "architecture": "qwen35",
+                "paramsString": "27B",
+                "quantization": {"name": "Q4_K_M", "bits": 4},
+                "sizeBytes": 17741858944,
+                "maxContextLength": 262144,
+            }
+        ]
+        mock_result = MagicMock(
+            returncode=0, stdout=_json.dumps(models_data)
+        )
+        with patch("subprocess.run", return_value=mock_result):
+            metadata = bm.ModelDiscovery.get_model_metadata(
+                "thinkingcap-qwen3.6-27b"
+            )
+
+        assert metadata["quantization"] == "Q4_K_M"
+        assert metadata["architecture"] == "qwen35"
+
+    def test_metadata_defaults_include_quantization_key(self):
+        """Unknown models still expose the quantization key as None."""
+        bm = _import_benchmark()
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            metadata = bm.ModelDiscovery.get_model_metadata("nope")
+
+        assert metadata["quantization"] is None
 
     def test_get_installed_models_returns_empty_on_error(self):
         """get_installed_models returns empty list when lms fails."""
@@ -751,15 +831,28 @@ class TestLMStudioBenchmarkStaticMethods:
             result = bm.LMStudioBenchmark.get_lmstudio_version()
         assert result is None
 
-    def test_get_nvidia_driver_version_success(self):
+    def test_get_nvidia_driver_version_success(self, monkeypatch):
         """get_nvidia_driver_version returns version string."""
         bm = _import_benchmark()
+        monkeypatch.setattr(bm, "IS_MACOS", False)
         with patch(
             "subprocess.run",
             return_value=MagicMock(returncode=0, stdout="535.104.05\n"),
         ):
             result = bm.LMStudioBenchmark.get_nvidia_driver_version()
         assert result is not None and "535" in result
+
+    def test_gpu_driver_versions_are_none_on_macos(self, monkeypatch):
+        """macOS ships no NVIDIA/ROCm/Intel tooling, so no probe runs."""
+        bm = _import_benchmark()
+        monkeypatch.setattr(bm, "IS_MACOS", True)
+
+        with patch("subprocess.run") as mock_run:
+            assert bm.LMStudioBenchmark.get_nvidia_driver_version() is None
+            assert bm.LMStudioBenchmark.get_rocm_driver_version() is None
+            assert bm.LMStudioBenchmark.get_intel_driver_version() is None
+
+        mock_run.assert_not_called()
 
     def test_get_nvidia_driver_version_returns_none_on_error(self):
         """get_nvidia_driver_version returns None when nvidia-smi fails."""

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -214,7 +214,13 @@ class TestHardwareMonitoring:
 
         assert monitor is not None
         assert monitor.enabled is True
-        assert monitor.gpu_type in ("NVIDIA", "AMD", "Intel", "Unknown")
+        assert monitor.gpu_type in (
+            "NVIDIA",
+            "AMD",
+            "Intel",
+            "Apple",
+            "Unknown",
+        )
 
 
 class TestBenchmarkAgentConfig:

--- a/tests/test_hardware_monitor.py
+++ b/tests/test_hardware_monitor.py
@@ -6,7 +6,167 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import tools.hardware_monitor as hw
 from tools.hardware_monitor import GPUMonitor, HardwareMonitor
+
+APPLE_GPU_INFO = {
+    "model": "Apple M4 Max",
+    "cores": 40,
+    "metal_family": "metal4",
+    "vendor": "Apple",
+}
+
+
+class TestAppleGpuDetection:
+    """Tests for Apple Silicon GPU support on macOS."""
+
+    def test_detect_gpu_finds_apple_silicon(self, monkeypatch):
+        """GPUMonitor reports Apple GPU type, model and ioreg tool."""
+        monkeypatch.setattr(hw, "IS_MACOS", True)
+        monkeypatch.setattr(
+            hw, "detect_apple_gpu", lambda: dict(APPLE_GPU_INFO)
+        )
+        monkeypatch.setattr(hw, "get_apple_unified_memory_gb", lambda: 64.0)
+        monkeypatch.setattr(hw, "is_macmon_available", lambda: False)
+
+        monitor = GPUMonitor()
+
+        assert monitor.gpu_type == "Apple"
+        assert monitor.gpu_tool == "ioreg"
+        assert monitor.gpu_model == "Apple M4 Max (40-core GPU)"
+
+    def test_detect_gpu_reports_macmon_when_installed(self, monkeypatch):
+        """gpu_tool advertises macmon when sudoless sampling is available."""
+        monkeypatch.setattr(hw, "IS_MACOS", True)
+        monkeypatch.setattr(
+            hw, "detect_apple_gpu", lambda: dict(APPLE_GPU_INFO)
+        )
+        monkeypatch.setattr(hw, "get_apple_unified_memory_gb", lambda: 64.0)
+        monkeypatch.setattr(hw, "is_macmon_available", lambda: True)
+
+        monitor = GPUMonitor()
+
+        assert monitor.gpu_tool == "macmon+ioreg"
+
+    def test_detect_gpu_skips_apple_branch_on_linux(self, monkeypatch):
+        """Linux never probes the Apple detection path."""
+        mock_detect = MagicMock()
+        monkeypatch.setattr(hw, "IS_MACOS", False)
+        monkeypatch.setattr(hw, "detect_apple_gpu", mock_detect)
+
+        with patch("shutil.which", return_value=None), \
+                patch("glob.glob", return_value=[]):
+            GPUMonitor()
+
+        mock_detect.assert_not_called()
+
+    def test_detect_gpu_falls_through_for_non_apple_vendor(self, monkeypatch):
+        """A non-Apple vendor on macOS falls through to the vendor tools."""
+        monkeypatch.setattr(hw, "IS_MACOS", True)
+        monkeypatch.setattr(
+            hw, "detect_apple_gpu", lambda: {**APPLE_GPU_INFO, "vendor": "amd"}
+        )
+
+        with patch("shutil.which", return_value=None), \
+                patch("glob.glob", return_value=[]):
+            monitor = GPUMonitor()
+
+        assert monitor.gpu_type == "Unknown"
+
+    def test_get_vram_usage_reports_megabytes(self):
+        """GPUMonitor.get_vram_usage converts unified memory GB to MB."""
+        monitor = GPUMonitor.__new__(GPUMonitor)
+        monitor.gpu_type = "Apple"
+        monitor.gpu_tool = "ioreg"
+        monitor.gpu_model = "Apple M4 Max"
+
+        with patch.object(
+            hw,
+            "read_apple_gpu_stats",
+            return_value={"utilization_percent": 16.0, "vram_used_gb": 2.2},
+        ):
+            assert monitor.get_vram_usage() == "2252"
+
+    def test_get_vram_usage_returns_na_without_stats(self):
+        """Unreadable ioreg statistics yield N/A rather than an exception."""
+        monitor = GPUMonitor.__new__(GPUMonitor)
+        monitor.gpu_type = "Apple"
+        monitor.gpu_tool = "ioreg"
+        monitor.gpu_model = "Apple M4 Max"
+
+        with patch(
+            "tools.hardware_monitor.read_apple_gpu_stats",
+            return_value={"utilization_percent": None, "vram_used_gb": None},
+        ):
+            assert monitor.get_vram_usage() == "N/A"
+
+    def test_hardware_monitor_reads_vram_in_gb(self):
+        """HardwareMonitor._get_vram_usage returns unified memory in GB."""
+        monitor = HardwareMonitor(
+            gpu_type="Apple", gpu_tool="ioreg", enabled=False
+        )
+        with patch.object(
+            hw,
+            "read_apple_gpu_stats",
+            return_value={"utilization_percent": 16.0, "vram_used_gb": 2.2},
+        ):
+            assert monitor._get_vram_usage() == 2.2
+
+    def test_temperature_and_power_unset_without_macmon(self, monkeypatch):
+        """Without macmon, temp and power would need root powermetrics."""
+        monkeypatch.setattr(hw, "is_macmon_available", lambda: False)
+        monitor = HardwareMonitor(
+            gpu_type="Apple", gpu_tool="ioreg", enabled=False
+        )
+        assert monitor._macmon is None
+        assert monitor._get_temperature() is None
+        assert monitor._get_power_draw() is None
+        assert monitor._get_gtt_usage() is None
+
+    def test_temperature_and_power_come_from_macmon(self, monkeypatch):
+        """With macmon installed, temp and power are sampled sudolessly."""
+        monkeypatch.setattr(hw, "is_macmon_available", lambda: True)
+
+        sampler = MagicMock()
+        sampler.get_gpu_temperature.return_value = 47.14
+        sampler.get_gpu_power.return_value = 12.5
+        monkeypatch.setattr(hw, "MacmonSampler", lambda *a, **k: sampler)
+
+        monitor = HardwareMonitor(
+            gpu_type="Apple", gpu_tool="macmon+ioreg", enabled=False
+        )
+
+        assert monitor._get_temperature() == 47.14
+        assert monitor._get_power_draw() == 12.5
+
+    def test_macmon_not_used_for_non_apple_gpus(self, monkeypatch):
+        """NVIDIA and AMD keep their own vendor tools."""
+        monkeypatch.setattr(hw, "is_macmon_available", lambda: True)
+        monitor = HardwareMonitor(
+            gpu_type="NVIDIA", gpu_tool="nvidia-smi", enabled=False
+        )
+        assert monitor._macmon is None
+
+    def test_macmon_lifecycle_follows_monitor(self, monkeypatch):
+        """The sampler starts with monitoring and stops with it."""
+        monkeypatch.setattr(hw, "is_macmon_available", lambda: True)
+
+        sampler = MagicMock()
+        sampler.start.return_value = True
+        sampler.get_gpu_temperature.return_value = 47.0
+        sampler.get_gpu_power.return_value = 12.5
+        monkeypatch.setattr(hw, "MacmonSampler", lambda *a, **k: sampler)
+
+        monitor = HardwareMonitor(
+            gpu_type="Apple", gpu_tool="macmon+ioreg", enabled=True
+        )
+        monitor.start()
+        sampler.start.assert_called_once()
+
+        stats = monitor.stop()
+        sampler.stop.assert_called_once()
+        assert stats["temp_celsius_max"] == 47.0
+        assert stats["power_watts_max"] == 12.5
 
 
 class TestHardwareMonitor:

--- a/tests/test_macmon.py
+++ b/tests/test_macmon.py
@@ -1,0 +1,274 @@
+"""Tests for tools/macmon.py (sudoless Apple Silicon power/temperature).
+
+The JSON fixtures below are trimmed copies of real ``macmon pipe`` output
+(macmon 0.8.0), so the tests do not need the binary installed.
+"""
+
+import json
+import subprocess
+import threading
+from unittest.mock import MagicMock, patch
+
+import tools.macmon as mm
+from tools.macmon import MacmonSampler
+
+SAMPLE = {
+    "all_power": 0.5507163405418396,
+    "ane_power": 0.0,
+    "cpu_power": 0.2923669219017029,
+    "gpu_active_ratio": 0.32043036818504333,
+    "gpu_freq_mhz": 338,
+    "gpu_power": 0.2583494186401367,
+    "memory": {
+        "ram_total": 68719476736,
+        "ram_usage": 16828694528,
+        "swap_total": 2147483648,
+        "swap_usage": 1135280128,
+    },
+    "sys_power": 7.6835761070251465,
+    "temp": {
+        "cpu_temp_avg": 50.0324592590332,
+        "gpu_temp_avg": 47.14311599731445,
+    },
+    "timestamp": "2026-07-31T02:28:40.726672+00:00",
+}
+
+NDJSON = json.dumps(SAMPLE) + "\n"
+
+
+def _sampler_with(sample):
+    """Build a sampler with a preloaded latest sample."""
+    sampler = MacmonSampler.__new__(MacmonSampler)
+    sampler._lock = threading.Lock()
+    sampler._latest = sample
+    return sampler
+
+
+class TestFindMacmon:
+    """Tests for find_macmon() and is_macmon_available()."""
+
+    def test_returns_none_off_macos(self, monkeypatch):
+        """Non-macOS platforms never look for the binary."""
+        monkeypatch.setattr(mm, "IS_MACOS", False)
+        with patch("shutil.which") as mock_which:
+            assert mm.find_macmon() is None
+        mock_which.assert_not_called()
+
+    def test_finds_binary_on_path(self, monkeypatch):
+        """A macmon on PATH is returned directly."""
+        monkeypatch.setattr(mm, "IS_MACOS", True)
+        with patch("shutil.which", return_value="/opt/homebrew/bin/macmon"):
+            assert mm.find_macmon() == "/opt/homebrew/bin/macmon"
+
+    def test_falls_back_to_homebrew_prefixes(self, monkeypatch):
+        """A GUI-launched process may lack Homebrew on PATH."""
+        monkeypatch.setattr(mm, "IS_MACOS", True)
+
+        def fake_which(_name, path=None):
+            if path == "/opt/homebrew/bin":
+                return "/opt/homebrew/bin/macmon"
+            return None
+
+        with patch("shutil.which", side_effect=fake_which):
+            assert mm.find_macmon() == "/opt/homebrew/bin/macmon"
+
+    def test_availability_reflects_lookup(self, monkeypatch):
+        """is_macmon_available mirrors find_macmon."""
+        monkeypatch.setattr(mm, "find_macmon", lambda: None)
+        assert mm.is_macmon_available() is False
+        monkeypatch.setattr(mm, "find_macmon", lambda: "/usr/local/bin/macmon")
+        assert mm.is_macmon_available() is True
+
+
+class TestMetricAccessors:
+    """Tests for the typed accessors over a parsed sample."""
+
+    def test_reads_temperatures(self):
+        """GPU and CPU temperatures come from the nested temp object."""
+        sampler = _sampler_with(SAMPLE)
+        assert round(sampler.get_gpu_temperature(), 2) == 47.14
+        assert round(sampler.get_cpu_temperature(), 2) == 50.03
+
+    def test_reads_power_fields(self):
+        """Power fields are returned in watts."""
+        sampler = _sampler_with(SAMPLE)
+        assert round(sampler.get_gpu_power(), 3) == 0.258
+        assert round(sampler.get_cpu_power(), 3) == 0.292
+        assert sampler.get_ane_power() == 0.0
+        assert round(sampler.get_total_power(), 3) == 0.551
+
+    def test_total_power_falls_back_to_sys_power(self):
+        """When all_power is absent, sys_power is used."""
+        sample = {k: v for k, v in SAMPLE.items() if k != "all_power"}
+        sampler = _sampler_with(sample)
+        assert round(sampler.get_total_power(), 2) == 7.68
+
+    def test_gpu_utilization_is_percentage(self):
+        """gpu_active_ratio is scaled from 0-1 to 0-100."""
+        sampler = _sampler_with(SAMPLE)
+        assert round(sampler.get_gpu_utilization(), 2) == 32.04
+
+    def test_returns_none_without_sample(self):
+        """Accessors return None before the first sample arrives."""
+        sampler = _sampler_with(None)
+        assert sampler.get_gpu_temperature() is None
+        assert sampler.get_gpu_power() is None
+        assert sampler.get_gpu_utilization() is None
+
+    def test_returns_none_for_missing_keys(self):
+        """A sample missing the requested field yields None."""
+        sampler = _sampler_with({"temp": {}})
+        assert sampler.get_gpu_temperature() is None
+        assert sampler.get_gpu_power() is None
+
+    def test_rejects_non_numeric_values(self):
+        """Non-numeric values are not coerced."""
+        sampler = _sampler_with(
+            {"gpu_power": "hot", "temp": {"gpu_temp_avg": None}}
+        )
+        assert sampler.get_gpu_power() is None
+        assert sampler.get_gpu_temperature() is None
+
+    def test_rejects_bool_values(self):
+        """Booleans are not treated as numbers."""
+        sampler = _sampler_with({"gpu_power": True})
+        assert sampler.get_gpu_power() is None
+
+
+class TestSamplerLifecycle:
+    """Tests for start/stop and the NDJSON reader loop."""
+
+    def test_start_returns_false_without_binary(self, monkeypatch):
+        """An unavailable macmon does not spawn a process."""
+        monkeypatch.setattr(mm, "find_macmon", lambda: None)
+        sampler = MacmonSampler()
+        with patch("subprocess.Popen") as mock_popen:
+            assert sampler.start() is False
+        mock_popen.assert_not_called()
+
+    def test_start_spawns_pipe_with_interval(self, monkeypatch):
+        """macmon is launched in pipe mode with the configured interval."""
+        monkeypatch.setattr(
+            mm, "find_macmon", lambda: "/opt/homebrew/bin/macmon"
+        )
+        sampler = MacmonSampler(interval_ms=500)
+
+        proc = MagicMock()
+        proc.stdout.__iter__.return_value = iter([])
+        proc.poll.return_value = None
+
+        with patch("subprocess.Popen", return_value=proc) as mock_popen:
+            assert sampler.start() is True
+
+        command = mock_popen.call_args[0][0]
+        assert command[0] == "/opt/homebrew/bin/macmon"
+        assert command[1] == "pipe"
+        assert "--interval" in command
+        assert "500" in command
+        sampler._running = False
+
+    def test_start_handles_launch_failure(self, monkeypatch):
+        """An OSError while spawning is reported as a failed start."""
+        monkeypatch.setattr(
+            mm, "find_macmon", lambda: "/opt/homebrew/bin/macmon"
+        )
+        sampler = MacmonSampler()
+        with patch("subprocess.Popen", side_effect=OSError("boom")):
+            assert sampler.start() is False
+
+    def test_interval_has_a_floor(self, monkeypatch):
+        """Absurdly small intervals are clamped."""
+        monkeypatch.setattr(
+            mm, "find_macmon", lambda: "/opt/homebrew/bin/macmon"
+        )
+        assert MacmonSampler(interval_ms=1).interval_ms == 100
+
+    def test_read_loop_parses_ndjson(self, monkeypatch):
+        """Each NDJSON line replaces the latest sample."""
+        monkeypatch.setattr(
+            mm, "find_macmon", lambda: "/opt/homebrew/bin/macmon"
+        )
+        sampler = MacmonSampler()
+
+        proc = MagicMock()
+        proc.stdout.__iter__.return_value = iter([NDJSON])
+        sampler._process = proc
+        sampler._running = True
+        sampler._read_loop()
+
+        assert round(sampler.get_gpu_temperature(), 2) == 47.14
+
+    def test_read_loop_skips_malformed_lines(self, monkeypatch):
+        """Unparsable lines are ignored, valid ones still land."""
+        monkeypatch.setattr(
+            mm, "find_macmon", lambda: "/opt/homebrew/bin/macmon"
+        )
+        sampler = MacmonSampler()
+
+        proc = MagicMock()
+        proc.stdout.__iter__.return_value = iter(["not json\n", "\n", NDJSON])
+        sampler._process = proc
+        sampler._running = True
+        sampler._read_loop()
+
+        assert round(sampler.get_gpu_power(), 3) == 0.258
+
+    def test_read_loop_ignores_non_object_json(self, monkeypatch):
+        """A JSON array is not a sample and is discarded."""
+        monkeypatch.setattr(
+            mm, "find_macmon", lambda: "/opt/homebrew/bin/macmon"
+        )
+        sampler = MacmonSampler()
+
+        proc = MagicMock()
+        proc.stdout.__iter__.return_value = iter(["[1, 2, 3]\n"])
+        sampler._process = proc
+        sampler._running = True
+        sampler._read_loop()
+
+        assert sampler.latest() is None
+
+    def test_stop_terminates_process(self, monkeypatch):
+        """stop() terminates a live process and clears state."""
+        monkeypatch.setattr(
+            mm, "find_macmon", lambda: "/opt/homebrew/bin/macmon"
+        )
+        sampler = MacmonSampler()
+
+        proc = MagicMock()
+        proc.poll.return_value = None
+        sampler._process = proc
+        sampler._running = True
+
+        sampler.stop()
+
+        proc.terminate.assert_called_once()
+        assert sampler._process is None
+
+    def test_stop_kills_when_terminate_times_out(self, monkeypatch):
+        """A process that ignores terminate is killed."""
+        monkeypatch.setattr(
+            mm, "find_macmon", lambda: "/opt/homebrew/bin/macmon"
+        )
+        sampler = MacmonSampler()
+
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.wait.side_effect = subprocess.TimeoutExpired(
+            cmd="macmon", timeout=2
+        )
+        sampler._process = proc
+        sampler._running = True
+
+        sampler.stop()
+
+        proc.kill.assert_called_once()
+
+    def test_stop_is_safe_without_process(self):
+        """stop() on a never-started sampler does nothing."""
+        sampler = MacmonSampler.__new__(MacmonSampler)
+        sampler._process = None
+        sampler._thread = None
+        sampler._running = False
+        sampler.stop()
+        assert sampler._process is None

--- a/tests/test_platform_info.py
+++ b/tests/test_platform_info.py
@@ -1,0 +1,297 @@
+"""Tests for core/platform_info.py (cross-platform OS and GPU detection)."""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import core.platform_info as pi
+
+
+SYSTEM_PROFILER_APPLE = json.dumps(
+    {
+        "SPDisplaysDataType": [
+            {
+                "_name": "Apple M4 Max",
+                "spdisplays_mtlgpufamilysupport": "spdisplays_metal4",
+                "spdisplays_vendor": "sppci_vendor_Apple",
+                "sppci_bus": "spdisplays_builtin",
+                "sppci_cores": "40",
+                "sppci_device_type": "spdisplays_gpu",
+                "sppci_model": "Apple M4 Max",
+            }
+        ]
+    }
+)
+
+IOREG_OUTPUT = (
+    '  | |   "PerformanceStatistics" = {"In use system memory (driver)"=0,'
+    '"Alloc system memory"=52967440384,"Tiler Utilization %"=10,'
+    '"recoveryCount"=0,"Device Utilization %"=16,'
+    '"In use system memory"=2363801600}\n'
+)
+
+
+def _ok(stdout: str) -> MagicMock:
+    """Build a successful CompletedProcess-like mock."""
+    return MagicMock(returncode=0, stdout=stdout)
+
+
+class TestRunTextCommand:
+    """Tests for _run_text_command()."""
+
+    def test_returns_stdout_on_success(self):
+        """Successful command returns its stdout."""
+        with patch("subprocess.run", return_value=_ok("value\n")):
+            assert pi._run_text_command(["true"]) == "value\n"
+
+    def test_returns_none_on_missing_binary(self):
+        """A missing binary yields None instead of raising."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert pi._run_text_command(["nope"]) is None
+
+    def test_returns_none_on_timeout(self):
+        """A timeout yields None instead of raising."""
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="x", timeout=5),
+        ):
+            assert pi._run_text_command(["slow"]) is None
+
+    def test_returns_none_on_nonzero_exit(self):
+        """Non-zero exit codes yield None."""
+        with patch(
+            "subprocess.run", return_value=MagicMock(returncode=1, stdout="")
+        ):
+            assert pi._run_text_command(["false"]) is None
+
+    def test_returns_none_on_blank_stdout(self):
+        """Whitespace-only stdout is treated as no result."""
+        with patch("subprocess.run", return_value=_ok("   \n")):
+            assert pi._run_text_command(["blank"]) is None
+
+
+class TestMacosNameVersion:
+    """Tests for get_macos_name_version()."""
+
+    def test_maps_known_major_release(self):
+        """A known major release gains its marketing name."""
+        with patch(
+            "platform.mac_ver", return_value=("26.6", ("", "", ""), "arm64")
+        ):
+            assert pi.get_macos_name_version() == ("macOS Tahoe", "26.6")
+
+    def test_maps_legacy_ten_dot_release(self):
+        """Legacy 10.x versions resolve on the two-part key."""
+        with patch(
+            "platform.mac_ver", return_value=("10.15.7", ("", "", ""), "x86_64")
+        ):
+            assert pi.get_macos_name_version() == ("macOS Catalina", "10.15.7")
+
+    def test_unknown_release_falls_back_to_plain_name(self):
+        """An unmapped release still reports a usable name and version."""
+        with patch(
+            "platform.mac_ver", return_value=("99.0", ("", "", ""), "arm64")
+        ):
+            assert pi.get_macos_name_version() == ("macOS", "99.0")
+
+    def test_empty_mac_ver_falls_back_to_release(self):
+        """An empty mac_ver falls back to platform.release()."""
+        with patch("platform.mac_ver", return_value=("", ("", "", ""), "")), \
+                patch("platform.release", return_value="25.6.0"):
+            name, version = pi.get_macos_name_version()
+        assert name == "macOS"
+        assert version == "25.6.0"
+
+
+class TestGetOsNameVersion:
+    """Tests for get_os_name_version()."""
+
+    def test_darwin_returns_macos_name(self):
+        """Darwin is reported as macOS, not as the Darwin kernel version."""
+        mac_ver = ("26.6", ("", "", ""), "arm64")
+        with patch("platform.system", return_value="Darwin"), \
+                patch("platform.mac_ver", return_value=mac_ver):
+            assert pi.get_os_name_version() == ("macOS Tahoe", "26.6")
+
+    def test_other_platform_uses_platform_values(self):
+        """Unknown systems fall back to platform name and release."""
+        with patch("platform.system", return_value="FreeBSD"), \
+                patch("platform.release", return_value="14.0"):
+            assert pi.get_os_name_version() == ("FreeBSD", "14.0")
+
+
+class TestOpenUrlCommand:
+    """Tests for get_open_url_command()."""
+
+    def test_macos_uses_open(self, monkeypatch):
+        """macOS uses the `open` command."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        monkeypatch.setattr(pi, "IS_LINUX", False)
+        assert pi.get_open_url_command() == "open"
+
+    def test_linux_uses_xdg_open(self, monkeypatch):
+        """Linux uses `xdg-open`."""
+        monkeypatch.setattr(pi, "IS_MACOS", False)
+        monkeypatch.setattr(pi, "IS_LINUX", True)
+        assert pi.get_open_url_command() == "xdg-open"
+
+
+class TestDetectAppleGpu:
+    """Tests for detect_apple_gpu()."""
+
+    def test_returns_none_off_macos(self, monkeypatch):
+        """Non-macOS platforms never probe system_profiler."""
+        monkeypatch.setattr(pi, "IS_MACOS", False)
+        with patch("subprocess.run") as mock_run:
+            assert pi.detect_apple_gpu() is None
+        mock_run.assert_not_called()
+
+    def test_parses_apple_silicon_gpu(self, monkeypatch):
+        """Apple Silicon GPU fields are extracted from system_profiler JSON."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        with patch("subprocess.run", return_value=_ok(SYSTEM_PROFILER_APPLE)):
+            info = pi.detect_apple_gpu()
+
+        assert info == {
+            "model": "Apple M4 Max",
+            "cores": 40,
+            "metal_family": "metal4",
+            "vendor": "Apple",
+        }
+
+    def test_handles_missing_core_count(self, monkeypatch):
+        """A GPU entry without a core count still resolves."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        payload = json.dumps(
+            {
+                "SPDisplaysDataType": [
+                    {
+                        "sppci_model": "AMD Radeon Pro 5500M",
+                        "spdisplays_vendor": "sppci_vendor_amd",
+                    }
+                ]
+            }
+        )
+        with patch("subprocess.run", return_value=_ok(payload)):
+            info = pi.detect_apple_gpu()
+
+        assert info["model"] == "AMD Radeon Pro 5500M"
+        assert info["cores"] is None
+        assert info["vendor"] == "amd"
+
+    def test_returns_none_on_invalid_json(self, monkeypatch):
+        """Malformed system_profiler output is handled gracefully."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        with patch("subprocess.run", return_value=_ok("not json")):
+            assert pi.detect_apple_gpu() is None
+
+    def test_returns_none_when_command_missing(self, monkeypatch):
+        """A missing system_profiler yields None."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert pi.detect_apple_gpu() is None
+
+
+class TestReadAppleGpuStats:
+    """Tests for read_apple_gpu_stats()."""
+
+    def test_parses_ioreg_performance_statistics(self, monkeypatch):
+        """Utilization and in-use memory are read from ioreg."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        with patch("subprocess.run", return_value=_ok(IOREG_OUTPUT)):
+            stats = pi.read_apple_gpu_stats()
+
+        assert stats["utilization_percent"] == 16.0
+        assert round(stats["vram_used_gb"], 2) == 2.2
+
+    def test_returns_empty_stats_off_macos(self, monkeypatch):
+        """Non-macOS platforms return empty stats without probing."""
+        monkeypatch.setattr(pi, "IS_MACOS", False)
+        with patch("subprocess.run") as mock_run:
+            stats = pi.read_apple_gpu_stats()
+
+        assert stats == {"utilization_percent": None, "vram_used_gb": None}
+        mock_run.assert_not_called()
+
+    def test_returns_empty_stats_without_statistics_block(self, monkeypatch):
+        """Output lacking PerformanceStatistics yields empty stats."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        with patch("subprocess.run", return_value=_ok("+-o IOAccelerator\n")):
+            stats = pi.read_apple_gpu_stats()
+
+        assert stats == {"utilization_percent": None, "vram_used_gb": None}
+
+
+class TestUnifiedMemoryAndChip:
+    """Tests for get_apple_unified_memory_gb() and get_apple_chip_name()."""
+
+    def test_unified_memory_converts_bytes_to_gb(self, monkeypatch):
+        """hw.memsize bytes are converted to GB."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        with patch("subprocess.run", return_value=_ok("68719476736\n")):
+            assert pi.get_apple_unified_memory_gb() == 64.0
+
+    def test_unified_memory_handles_non_numeric(self, monkeypatch):
+        """Unparsable sysctl output yields None."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        with patch("subprocess.run", return_value=_ok("banana\n")):
+            assert pi.get_apple_unified_memory_gb() is None
+
+    def test_unified_memory_none_off_macos(self, monkeypatch):
+        """Non-macOS platforms return None."""
+        monkeypatch.setattr(pi, "IS_MACOS", False)
+        assert pi.get_apple_unified_memory_gb() is None
+
+    def test_chip_name_from_sysctl(self, monkeypatch):
+        """The CPU brand string is returned verbatim."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+        with patch("subprocess.run", return_value=_ok("Apple M4 Max\n")):
+            assert pi.get_apple_chip_name() == "Apple M4 Max"
+
+    def test_chip_name_none_off_macos(self, monkeypatch):
+        """Non-macOS platforms return None."""
+        monkeypatch.setattr(pi, "IS_MACOS", False)
+        assert pi.get_apple_chip_name() is None
+
+
+class TestMetalDriverVersion:
+    """Tests for get_metal_driver_version()."""
+
+    def test_includes_metal_family_and_build(self, monkeypatch):
+        """Metal family and macOS build are combined."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "system_profiler":
+                return _ok(SYSTEM_PROFILER_APPLE)
+            return _ok("25G72\n")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = pi.get_metal_driver_version()
+
+        assert result == "metal4 (macOS build 25G72)"
+
+    def test_falls_back_without_gpu_info(self, monkeypatch):
+        """Only the build is reported when no GPU is detected."""
+        monkeypatch.setattr(pi, "IS_MACOS", True)
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "system_profiler":
+                return MagicMock(returncode=1, stdout="")
+            return _ok("25G72\n")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            assert pi.get_metal_driver_version() == "macOS build 25G72"
+
+    def test_none_off_macos(self, monkeypatch):
+        """Non-macOS platforms return None."""
+        monkeypatch.setattr(pi, "IS_MACOS", False)
+        assert pi.get_metal_driver_version() is None
+
+
+class TestPlatformFlags:
+    """Tests for the module-level platform flags."""
+
+    def test_at_most_one_flag_matches_current_platform(self):
+        """The flags are mutually exclusive for the running platform."""
+        assert sum([pi.IS_MACOS, pi.IS_LINUX, pi.IS_WINDOWS]) <= 1

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -18,6 +18,24 @@ import pytest
 _RUN_MODULE = None
 
 
+@pytest.fixture(autouse=True)
+def _pin_linux_platform(monkeypatch):
+    """Pin platform flags to Linux for this module.
+
+    run.py's AppImage bootstrapping and GTK tray launch are Linux-only, and
+    the tests below assert that Linux behaviour. macOS-specific gating is
+    covered separately in TestPlatformGating.
+    """
+    import core.platform_info as platform_info
+
+    monkeypatch.setattr(platform_info, "IS_LINUX", True)
+    monkeypatch.setattr(platform_info, "IS_MACOS", False)
+
+    if _RUN_MODULE is not None:
+        monkeypatch.setattr(_RUN_MODULE, "IS_LINUX", True)
+        monkeypatch.setattr(_RUN_MODULE, "IS_MACOS", False)
+
+
 def _import_run():
     """Import run.py safely by patching subprocess and sys.exit."""
     global _RUN_MODULE
@@ -228,6 +246,77 @@ class TestBuildSubprocessEnv:
         value = env.get("GI_TYPELIB_PATH", "")
         assert str(gi_arch_dir) in value
         assert value.endswith("/already/present")
+
+
+class TestPlatformGating:
+    """Tests for macOS/non-Linux platform gating in run.py."""
+
+    def test_macos_skips_appimage_gi_bootstrap(self, tmp_path, monkeypatch):
+        """AppImage GI_TYPELIB_PATH setup is Linux-only."""
+        run = _import_run()
+
+        project_root = tmp_path / "a" / "b" / "project"
+        project_root.mkdir(parents=True)
+        appdir = project_root.parents[2]
+        (appdir / "usr" / "lib" / "girepository-1.0").mkdir(parents=True)
+
+        monkeypatch.setattr(run, "project_root", project_root)
+        monkeypatch.setattr(run, "IS_LINUX", False)
+        monkeypatch.setattr(run, "IS_MACOS", True)
+        monkeypatch.delenv("GI_TYPELIB_PATH", raising=False)
+
+        env = run._build_subprocess_env()
+        assert "GI_TYPELIB_PATH" not in env
+
+    def test_macos_strips_dyld_variables(self, monkeypatch):
+        """DYLD_* injection variables are removed from the child env."""
+        run = _import_run()
+        monkeypatch.setenv("DYLD_LIBRARY_PATH", "/evil/lib")
+        monkeypatch.setenv("DYLD_INSERT_LIBRARIES", "/evil/hook.dylib")
+        monkeypatch.setenv("DYLD_FRAMEWORK_PATH", "/evil/frameworks")
+
+        env = run._build_subprocess_env()
+
+        assert "DYLD_LIBRARY_PATH" not in env
+        assert "DYLD_INSERT_LIBRARIES" not in env
+        assert "DYLD_FRAMEWORK_PATH" not in env
+
+    def test_tray_skipped_on_macos_without_gi(self, monkeypatch):
+        """macOS without PyGObject reports a skip reason instead of launching."""
+        run = _import_run()
+        monkeypatch.setattr(run, "IS_LINUX", False)
+        monkeypatch.setattr(run, "IS_MACOS", True)
+
+        with patch.object(run.importlib.util, "find_spec", return_value=None):
+            reason = run._tray_skip_reason()
+
+        assert reason is not None
+        assert "Linux-only" in reason
+
+    def test_tray_always_attempted_on_linux(self, monkeypatch):
+        """Linux keeps trying interpreters even when gi is not importable."""
+        run = _import_run()
+        monkeypatch.setattr(run, "IS_LINUX", True)
+        monkeypatch.setattr(run, "IS_MACOS", False)
+
+        with patch.object(run.importlib.util, "find_spec", return_value=None):
+            assert run._tray_skip_reason() is None
+
+    def test_start_tray_process_returns_none_when_skipped(
+        self, tmp_path, monkeypatch
+    ):
+        """_start_tray_process short-circuits without spawning a process."""
+        run = _import_run()
+        monkeypatch.setattr(run, "project_root", tmp_path)
+        monkeypatch.setattr(run, "IS_LINUX", False)
+        monkeypatch.setattr(run, "IS_MACOS", True)
+
+        with patch.object(run.importlib.util, "find_spec", return_value=None), \
+                patch("subprocess.Popen") as mock_popen:
+            result = run._start_tray_process("http://localhost:8080", False)
+
+        assert result is None
+        mock_popen.assert_not_called()
 
 
 class TestSanitizeCliArgs:

--- a/tools/hardware_monitor.py
+++ b/tools/hardware_monitor.py
@@ -13,6 +13,14 @@ from typing import Dict, List, Optional
 
 import psutil
 
+from core.platform_info import (
+    IS_MACOS,
+    detect_apple_gpu,
+    get_apple_unified_memory_gb,
+    read_apple_gpu_stats,
+)
+from tools.macmon import MacmonSampler, is_macmon_available
+
 try:
     import cpuinfo
 except (ImportError, ModuleNotFoundError):
@@ -46,6 +54,13 @@ class HardwareMonitor:
         self.lock = threading.Lock()
         self._amd_sysfs_path: Optional[str] = None
         self._amd_hwmon_path: Optional[str] = None
+
+        # Apple Silicon exposes temperature and power only through
+        # powermetrics (root) or macmon (sudoless). macmon is optional: when
+        # absent, those metrics simply stay unset.
+        self._macmon: Optional[MacmonSampler] = None
+        if self.gpu_type == "Apple" and is_macmon_available():
+            self._macmon = MacmonSampler()
 
         if self.gpu_type == "AMD" and self.gpu_tool == "sysfs":
             self._init_amd_sysfs_paths()
@@ -103,6 +118,10 @@ class HardwareMonitor:
         )
         self.monitoring = True
         self._reset_measurements()
+
+        if self._macmon is not None and not self._macmon.start():
+            logger.debug("macmon could not be started; temp/power stay unset")
+
         self.thread = threading.Thread(target=self._monitor_loop, daemon=True)
         self.thread.start()
 
@@ -111,6 +130,9 @@ class HardwareMonitor:
         self.monitoring = False
         if self.thread:
             self.thread.join(timeout=2)
+
+        if self._macmon is not None:
+            self._macmon.stop()
 
         with self.lock:
             temps = self.temps.copy()
@@ -214,6 +236,11 @@ class HardwareMonitor:
             if not self.gpu_tool:
                 return None
 
+            if self.gpu_type == "Apple":
+                if self._macmon is None:
+                    return None
+                return self._macmon.get_gpu_temperature()
+
             if self.gpu_type == "NVIDIA":
                 result = subprocess.run(
                     [
@@ -268,6 +295,11 @@ class HardwareMonitor:
         try:
             if not self.gpu_tool:
                 return None
+
+            if self.gpu_type == "Apple":
+                if self._macmon is None:
+                    return None
+                return self._macmon.get_gpu_power()
 
             if self.gpu_type == "NVIDIA":
                 result = subprocess.run(
@@ -331,6 +363,9 @@ class HardwareMonitor:
                 if result.returncode == 0:
                     vram_mb = float(result.stdout.strip().split("\n")[0])
                     return vram_mb / 1024.0
+
+            if self.gpu_type == "Apple":
+                return read_apple_gpu_stats()["vram_used_gb"]
 
             if self.gpu_type == "AMD":
                 if self.gpu_tool == "sysfs" and self._amd_sysfs_path:
@@ -472,8 +507,45 @@ class GPUMonitor:
             )
         return None
 
+    def _detect_apple_gpu(self) -> bool:
+        """Detect an Apple Silicon GPU on macOS.
+
+        Returns:
+            True when an Apple GPU was detected and state was set.
+        """
+        gpu_info = detect_apple_gpu()
+        if not gpu_info or gpu_info.get("vendor") != "Apple":
+            return False
+
+        self.gpu_type = "Apple"
+        # VRAM always comes from ioreg; macmon adds sudoless temperature and
+        # power on top when it is installed.
+        has_macmon = is_macmon_available()
+        self.gpu_tool = "macmon+ioreg" if has_macmon else "ioreg"
+
+        model = gpu_info["model"]
+        cores = gpu_info.get("cores")
+        self.gpu_model = f"{model} ({cores}-core GPU)" if cores else model
+
+        unified_memory_gb = get_apple_unified_memory_gb()
+        logger.info(
+            "🍎 Apple GPU detected: %s, unified memory: %s GB, Tool: %s",
+            self.gpu_model,
+            unified_memory_gb if unified_memory_gb is not None else "unknown",
+            self.gpu_tool,
+        )
+        if not has_macmon:
+            logger.info(
+                "💡 Install macmon (brew install macmon) for sudoless GPU "
+                "temperature and power metrics."
+            )
+        return True
+
     def _detect_gpu(self) -> None:
         """Detect GPU type and corresponding monitoring tool."""
+        if IS_MACOS and self._detect_apple_gpu():
+            return
+
         nvidia_paths = ["/usr/bin", "/usr/local/bin", "/usr/local/cuda/bin"]
         nvidia_tool = self._find_tool("nvidia-smi", nvidia_paths)
         if nvidia_tool:
@@ -643,6 +715,12 @@ class GPUMonitor:
             return "N/A"
 
         try:
+            if self.gpu_type == "Apple":
+                vram_used_gb = read_apple_gpu_stats()["vram_used_gb"]
+                if vram_used_gb is not None:
+                    return f"{int(vram_used_gb * 1024)}"
+                return "N/A"
+
             if self.gpu_type == "NVIDIA":
                 result = subprocess.run(
                     [

--- a/tools/macmon.py
+++ b/tools/macmon.py
@@ -1,0 +1,272 @@
+"""Sudoless Apple Silicon power and temperature sampling via ``macmon``.
+
+macOS exposes GPU temperature and power draw only through ``powermetrics``,
+which requires root. `macmon <https://github.com/vladkens/macmon>`_ reads the
+same counters through a private macOS API without elevated privileges, which
+makes it usable from an unattended benchmark run.
+
+``macmon pipe`` streams newline-delimited JSON, one sample per interval::
+
+    {"gpu_power": 0.258, "temp": {"gpu_temp_avg": 47.1, ...}, ...}
+
+The tool is entirely optional. When it is missing, or when its output cannot
+be parsed, callers fall back to leaving temperature and power unset rather
+than failing the benchmark.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import threading
+from typing import Any, Dict, Optional
+
+from core.platform_info import IS_MACOS
+
+logger = logging.getLogger(__name__)
+
+MACMON_BINARY = "macmon"
+
+# macmon is a Homebrew/cargo install, so it is not always on the PATH of a
+# GUI-launched process. These are the standard Homebrew prefixes.
+_MACMON_SEARCH_PATHS = [
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+]
+
+
+def find_macmon() -> Optional[str]:
+    """Locate the macmon binary.
+
+    Returns:
+        Path or bare command name when found, otherwise None.
+    """
+    if not IS_MACOS:
+        return None
+
+    found = shutil.which(MACMON_BINARY)
+    if found:
+        return found
+
+    for path in _MACMON_SEARCH_PATHS:
+        found = shutil.which(MACMON_BINARY, path=path)
+        if found:
+            return found
+
+    return None
+
+
+def is_macmon_available() -> bool:
+    """Report whether sudoless power/temperature sampling is possible."""
+    return find_macmon() is not None
+
+
+class MacmonSampler:
+    """Background reader for a streaming ``macmon pipe`` process.
+
+    A single long-lived subprocess is spawned and its NDJSON output is read
+    on a daemon thread, keeping only the most recent sample. This avoids
+    paying process start-up cost on every poll, which a per-metric invocation
+    would incur once per second.
+    """
+
+    def __init__(self, interval_ms: int = 1000):
+        """Initialize the sampler.
+
+        Args:
+            interval_ms: macmon sampling interval in milliseconds.
+        """
+        self.interval_ms = max(int(interval_ms), 100)
+        self.binary = find_macmon()
+        self._process: Optional[subprocess.Popen] = None
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+        self._latest: Optional[Dict[str, Any]] = None
+        self._running = False
+
+    @property
+    def available(self) -> bool:
+        """Whether the macmon binary was found."""
+        return self.binary is not None
+
+    def start(self) -> bool:
+        """Start the background macmon process.
+
+        Returns:
+            True when sampling started, False when macmon is unavailable or
+            could not be launched.
+        """
+        if not self.available or self._running:
+            return self._running
+
+        command = [
+            str(self.binary),
+            "pipe",
+            "--interval",
+            str(self.interval_ms),
+        ]
+
+        try:
+            self._process = subprocess.Popen(  # nosec B603
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                bufsize=1,
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            logger.debug("Could not start macmon: %s", error)
+            self._process = None
+            return False
+
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._read_loop,
+            name="macmon-sampler",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "🍏 macmon sampling started (sudoless power/temperature, %sms)",
+            self.interval_ms,
+        )
+        return True
+
+    def _read_loop(self) -> None:
+        """Consume NDJSON lines and keep the most recent sample."""
+        process = self._process
+        if process is None or process.stdout is None:
+            return
+
+        try:
+            for line in process.stdout:
+                if not self._running:
+                    break
+
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    sample = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.debug("Skipping unparsable macmon line")
+                    continue
+
+                if isinstance(sample, dict):
+                    with self._lock:
+                        self._latest = sample
+        except (OSError, ValueError) as error:
+            logger.debug("macmon reader stopped: %s", error)
+        finally:
+            try:
+                process.stdout.close()
+            except OSError:
+                pass
+
+    def stop(self) -> None:
+        """Terminate the macmon process and stop the reader thread."""
+        self._running = False
+
+        process = self._process
+        if process is not None and process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=2)
+            except (subprocess.SubprocessError, OSError, TimeoutError):
+                try:
+                    process.kill()
+                except (subprocess.SubprocessError, OSError):
+                    pass
+
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+
+        self._process = None
+        self._thread = None
+
+    def latest(self) -> Optional[Dict[str, Any]]:
+        """Return the most recent sample, or None when nothing was read yet."""
+        with self._lock:
+            return self._latest
+
+    def _read_float(self, *path: str) -> Optional[float]:
+        """Read a nested numeric field from the latest sample.
+
+        Args:
+            *path: Nested key path, e.g. ``("temp", "gpu_temp_avg")``.
+
+        Returns:
+            The value as a float, or None when absent or non-numeric.
+        """
+        sample: Any = self.latest()
+        if sample is None:
+            return None
+
+        for key in path:
+            if not isinstance(sample, dict) or key not in sample:
+                return None
+            sample = sample[key]
+
+        if isinstance(sample, bool) or not isinstance(sample, (int, float)):
+            return None
+        return float(sample)
+
+    def get_gpu_temperature(self) -> Optional[float]:
+        """Return average GPU temperature in degrees Celsius."""
+        return self._read_float("temp", "gpu_temp_avg")
+
+    def get_cpu_temperature(self) -> Optional[float]:
+        """Return average CPU temperature in degrees Celsius."""
+        return self._read_float("temp", "cpu_temp_avg")
+
+    def get_gpu_power(self) -> Optional[float]:
+        """Return GPU power draw in watts.
+
+        This mirrors the meaning of ``nvidia-smi --query-gpu=power.draw`` so
+        results stay comparable across platforms.
+        """
+        return self._read_float("gpu_power")
+
+    def get_cpu_power(self) -> Optional[float]:
+        """Return CPU package power draw in watts."""
+        return self._read_float("cpu_power")
+
+    def get_ane_power(self) -> Optional[float]:
+        """Return Apple Neural Engine power draw in watts."""
+        return self._read_float("ane_power")
+
+    def get_total_power(self) -> Optional[float]:
+        """Return total SoC power in watts.
+
+        Falls back to whole-system power when the SoC total is unavailable.
+        """
+        total = self._read_float("all_power")
+        if total is None:
+            total = self._read_float("sys_power")
+        return total
+
+    def get_gpu_utilization(self) -> Optional[float]:
+        """Return GPU active residency as a percentage (0-100)."""
+        ratio = self._read_float("gpu_active_ratio")
+        if ratio is None:
+            return None
+        return ratio * 100.0
+
+    def __enter__(self) -> "MacmonSampler":
+        """Start sampling on context entry."""
+        self.start()
+        return self
+
+    def __exit__(self, *_exc_info: Any) -> None:
+        """Stop sampling on context exit."""
+        self.stop()
+
+
+__all__ = [
+    "MacmonSampler",
+    "find_macmon",
+    "is_macmon_available",
+]

--- a/web/app.py
+++ b/web/app.py
@@ -42,7 +42,6 @@ import webbrowser
 import zipfile
 
 import cpuinfo
-import distro
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -51,9 +50,21 @@ from jinja2 import Environment, FileSystemLoader
 import psutil
 from pydantic import BaseModel
 
+# Linux-only distribution helper; absent on macOS and Windows.
+try:
+    import distro
+except (ImportError, ModuleNotFoundError):
+    distro = None
+
 from core.config import DEFAULT_CONFIG
 from core.logging_utils import install_level_icons
 from core.paths import USER_LOGS_DIR, USER_RESULTS_DIR, format_path_for_logs
+from core.platform_info import (
+    detect_apple_gpu,
+    get_apple_chip_name,
+    get_apple_unified_memory_gb,
+    get_macos_name_version,
+)
 from core.presets import PresetManager
 
 try:
@@ -1075,7 +1086,7 @@ class InferenceParamSet(BaseModel):
 
 
 class CreateExperimentRequest(BaseModel):
-    """Request zum Erstellen eines A/B Experiments"""
+    """Request payload for creating an A/B experiment"""
 
     name: str
     model_name: str
@@ -1116,7 +1127,7 @@ class PresetCompareRequest(BaseModel):
 
 
 def calculate_hash(params: Dict[str, Any]) -> str:
-    """Erstelle SHA256-Hash aus Parameter-Dictionary"""
+    """Create a SHA256 hash from a parameter dictionary"""
     params_str = json.dumps(params, sort_keys=True, default=str)
     return hashlib.sha256(params_str.encode()).hexdigest()[:16]
 
@@ -1530,7 +1541,7 @@ async def get_status() -> dict:
 
 @app.get("/api/lmstudio/health")
 async def get_lmstudio_health() -> dict:
-    """LM Studio Healthcheck - Live Status ohne Cache"""
+    """LM Studio healthcheck - live status without cache"""
     lmstudio_ports = LMSTUDIO_PORTS
 
     for lm_port in lmstudio_ports:
@@ -2886,7 +2897,7 @@ async def get_advanced_statistics(model_name: str) -> dict:
 
 @app.get("/api/output")
 async def get_output() -> dict:
-    """Gibt aktuellen Output"""
+    """Return the current output"""
     return {"output": manager.current_output, "status": manager.status}
 
 
@@ -4563,8 +4574,18 @@ async def get_dashboard_stats() -> dict:
             "ram_gb": round(psutil.virtual_memory().total / (1024**3), 2),
         }
 
+        if system_info["os"] == "Darwin":
+            macos_name, macos_version = get_macos_name_version()
+            system_info["os"] = macos_name
+            system_info["os_version"] = macos_version
+            apple_chip = get_apple_chip_name()
+            if apple_chip:
+                system_info["cpu"] = apple_chip
+
         if system_info["os"] == "Linux":
             try:
+                if distro is None:
+                    raise ImportError("distro package not installed")
 
                 distro_name = distro.name()
                 distro_version = distro.version()
@@ -4610,6 +4631,7 @@ async def get_dashboard_stats() -> dict:
             gpu_model = "Unknown"
             vram_total_gb = None
             gtt_total_gb = None
+            metal_family = None
 
             if results:
                 gpu_model = results[0].gpu_type
@@ -4626,6 +4648,23 @@ async def get_dashboard_stats() -> dict:
                     gpu_type = "Intel"
                 else:
                     gpu_type = gpu_model
+
+            # Apple Silicon shares one unified memory pool, so total "VRAM"
+            # is system RAM. Detect it first: macOS ships none of the
+            # nvidia-smi/rocm-smi/lspci tooling probed below.
+            apple_gpu = detect_apple_gpu()
+            if apple_gpu and apple_gpu.get("vendor") == "Apple":
+                gpu_type = "Apple"
+                cores = apple_gpu.get("cores")
+                gpu_model = (
+                    f"{apple_gpu['model']} ({cores}-core GPU)"
+                    if cores
+                    else apple_gpu["model"]
+                )
+                metal_family = apple_gpu.get("metal_family")
+                vram_total_gb = (
+                    get_apple_unified_memory_gb() or system_info["ram_gb"]
+                )
 
             try:
                 output = subprocess.check_output(
@@ -4815,17 +4854,34 @@ async def get_dashboard_stats() -> dict:
                 except (TimeoutExpired, FileNotFoundError):
                     pass
 
-            gpu_info = {
-                "type": gpu_type,
-                "model": gpu_model,
-                "vram_gb": vram_total_gb,
-                "gtt_gb": gtt_total_gb if gtt_total_gb else system_info["ram_gb"],
-                "total_gb": (
-                    (vram_total_gb + gtt_total_gb)
-                    if (vram_total_gb and gtt_total_gb)
-                    else (vram_total_gb or system_info["ram_gb"])
-                ),
-            }
+            if gpu_type == "Apple":
+                # Unified memory: VRAM and system RAM are one pool, so the
+                # totals must not be added together.
+                gpu_info = {
+                    "type": gpu_type,
+                    "model": gpu_model,
+                    "vram_gb": vram_total_gb,
+                    "gtt_gb": None,
+                    "total_gb": vram_total_gb,
+                    "unified_memory": True,
+                    "metal": metal_family,
+                }
+            else:
+                gpu_info = {
+                    "type": gpu_type,
+                    "model": gpu_model,
+                    "vram_gb": vram_total_gb,
+                    "gtt_gb": (
+                        gtt_total_gb if gtt_total_gb else system_info["ram_gb"]
+                    ),
+                    "total_gb": (
+                        (vram_total_gb + gtt_total_gb)
+                        if (vram_total_gb and gtt_total_gb)
+                        else (vram_total_gb or system_info["ram_gb"])
+                    ),
+                    "unified_memory": False,
+                    "metal": None,
+                }
 
         except (subprocess.SubprocessError, OSError, ValueError):
             gpu_info = {
@@ -4833,6 +4889,8 @@ async def get_dashboard_stats() -> dict:
                 "vram_gb": None,
                 "gtt_gb": system_info["ram_gb"],
                 "total_gb": system_info["ram_gb"],
+                "unified_memory": False,
+                "metal": None,
             }
 
         classic_models = {r.model_name for r in results}

--- a/web/templates/dashboard.html.jinja
+++ b/web/templates/dashboard.html.jinja
@@ -2601,14 +2601,14 @@
                             padding: 1.5rem;
                             border-radius: 0.75rem;
                             box-shadow: 0 1px 3px rgba(0,0,0,0.1)">
-                  <h3 style="color: var(--text); margin-bottom: 1rem;">📋 Detaillierte Verlauf</h3>
+                  <h3 style="color: var(--text); margin-bottom: 1rem;">📋 Detailed History</h3>
                   <div style="overflow-x: auto;">
                     <table id="comparison-history-table"
                            style="width: 100%;
                                   border-collapse: collapse">
                       <thead style="background: var(--primary); color: white;">
                         <tr>
-                          <th style="padding: 0.75rem; text-align: left;">Datum</th>
+                          <th style="padding: 0.75rem; text-align: left;">Date</th>
                           <th style="padding: 0.75rem; text-align: right;">Speed (tok/s)</th>
                           <th style="padding: 0.75rem; text-align: right;">TTFT (ms)</th>
                           <th style="padding: 0.75rem; text-align: right;">Gen-Time (ms)</th>
@@ -2776,7 +2776,7 @@
                 <label style="color: var(--text); font-weight: 500;">Experiment Name:</label>
                 <input type="text"
                        id="ab-experiment-name"
-                       placeholder="z.B. Temperature Test"
+                       placeholder="e.g. Temperature Test"
                        style="padding: 0.65rem;
                               border: 1px solid var(--border);
                               border-radius: 0.5rem;
@@ -2795,12 +2795,11 @@
                   <option value="">Select model...</option>
                 </select>
               </div>
-              <div class="form-group"
-                   style="display:flex;
-                          align-items:center;
-                          gap:0.5rem">
-                <input type="checkbox" id="ab-active-run-toggle" />
-                <label for="ab-active-run-toggle" style="margin:0;">Execute actively (start 2 benchmarks)</label>
+              <div class="form-group">
+                <div class="checkbox-item">
+                  <input type="checkbox" id="ab-active-run-toggle" />
+                  <label for="ab-active-run-toggle">Execute actively (start 2 benchmarks)</label>
+                </div>
               </div>
 
               <div style="border-top: 1px solid var(--border);
@@ -3307,7 +3306,7 @@
                             border-radius: 0.75rem;
                             border: 1px solid var(--border);
                             margin-bottom: 2rem">
-                  <h3 style="color: var(--primary); margin-bottom: 1rem;">📊 Speed Trend Vergleich</h3>
+                  <h3 style="color: var(--primary); margin-bottom: 1rem;">📊 Speed Trend Comparison</h3>
                   <div id="ab-speed-chart" style="width: 100%; height: 300px;"></div>
                 </div>
 
@@ -3458,7 +3457,7 @@
 
       <!-- Back to Top Button -->
       <button class="back-to-top"
-              title="Nach oben scrollen"
+              title="Scroll to top"
               onclick="scrollToTop()">↑</button>
 
       <!-- Toast Container -->
@@ -3577,7 +3576,7 @@
                 document.body.classList.add(themeName);
             }
             
-            // Speichern in LocalStorage
+            // Save to LocalStorage
             localStorage.setItem('theme', themeName);
         }
 
@@ -3691,17 +3690,17 @@
 
         // Set up theme on load
         // Initialize results on load
-        // WebSocket & Timers starten
+        // Start WebSocket & timers
         window.addEventListener('DOMContentLoaded', () => {
             applyConfigDefaults();
             updateBenchmarkModeUI();
             // Stelle Theme aus localStorage wieder her
             restoreTheme();
             
-            // Lade Dashboard-Stats wenn Home-View aktiv
+            // Load dashboard stats when the home view is active
             loadDashboardStats();
             
-            // Lade Results
+            // Load results
             loadResults();
             
             // Aktualisiere Export-Links
@@ -4135,7 +4134,7 @@
 
             const layout = {
                 title: {
-                    text: 'Top 10 Modelle nach Geschwindigkeit',
+                    text: 'Top 10 Models by Speed',
                     font: { size: 14 }
                 },
                 margin: { l: 170, r: 15, t: 40, b: 40 },
@@ -4189,7 +4188,7 @@
 
             const layout = {
                 title: {
-                    text: 'Quantization-Verteilung',
+                    text: 'Quantization Distribution',
                     font: { size: 14 }
                 },
                 margin: { l: 10, r: 10, t: 40, b: 10 },
@@ -4313,7 +4312,7 @@
         function setupWebSocket() {
             const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
             const wsUrl = `${protocol}//${window.location.host}/ws/benchmark`;
-            console.log('🔌 Versuche WebSocket Verbindung zu:', wsUrl);
+            console.log('🔌 Attempting WebSocket connection to:', wsUrl);
             
             websocket = new WebSocket(wsUrl);
 
@@ -4342,7 +4341,7 @@
                     }
                     // Update export links with new results
                     updateExportLinks();
-                    // Lade Results neu
+                    // Reload results
                     setTimeout(() => {
                         loadResults();
                         updateCacheStats();
@@ -4355,9 +4354,9 @@
             websocket.onerror = (error) => {
                 console.error('❌ WebSocket Error:', error);
                 addAlert('⚠️ WebSocket Error (trying to reconnect...)', 'warning');
-                // Versuche Reconnect nach 3 Sekunden
+                // Retry the connection after 3 seconds
                 setTimeout(() => {
-                    console.log('🔄 Versuche WebSocket Reconnect...');
+                    console.log('🔄 Attempting WebSocket reconnect...');
                     setupWebSocket();
                 }, 3000);
             };
@@ -4374,7 +4373,7 @@
             };
         }
 
-        // ===== Terminal Ausgabe =====
+        // ===== Terminal output =====
         function appendTerminalLine(line) {
             const terminals = [];
             const termMain = document.getElementById('terminal');
@@ -4514,7 +4513,7 @@
                     parseInt(document.getElementById('paramAgentMaxTests').value) ||
                     null,
                 
-                // Neue Filter-Parameter
+                // New filter parameters
                 min_context: parseInt(document.getElementById('paramMinContext').value) || null,
                 max_size: parseFloat(document.getElementById('paramMaxSize').value) || null,
                 quants: document.getElementById('paramQuants').value || null,
@@ -4638,7 +4637,7 @@
 
         async function loadResults() {
             try {
-                console.log('📥 Lade Results von /api/results + /api/results/raw...');
+                console.log('📥 Loading results from /api/results + /api/results/raw...');
                 const [summaryResp, rawResp] = await Promise.all([
                     fetch('/api/results'),
                     fetch('/api/results/raw?limit=200'),
@@ -4912,7 +4911,7 @@
                 return;
             }
 
-            // Sortieren mit defensiven Defaults
+            // Sort with defensive defaults
             const sorted = [...resultsData].sort((a, b) => {
                 let aVal, bVal;
                 switch(sortColumn) {
@@ -5398,7 +5397,7 @@
                     comparisonStats = data.stats;
                     populateQuantizationFilters(comparisonHistory);
                     await loadAdvancedStatistics(modelName);
-                    // Rendering direkt hier statt applyComparisonFilters aufzurufen
+                    // Render inline instead of calling applyComparisonFilters
                     renderComparisonData();
                 } else {
                     document.getElementById('comparison-charts-container').style.display = 'none';
@@ -5452,7 +5451,7 @@
                 await loadModelHistory(selectedModel);
                 return; // loadModelHistory ruft renderComparisonData auf
             }
-            // Sonst nur Rendering mit aktuellen Filtern
+            // Otherwise just re-render with the current filters
             renderComparisonData();
         }
 
@@ -5793,7 +5792,7 @@
                 case 'start':
                 default:
                     console.log('🚀 Setting button to START state');
-                    btn.innerHTML = '🚀 Experiment starten';
+                    btn.innerHTML = '🚀 Start Experiment';
                     btn.style.background = 'var(--primary)';
                     btn.disabled = false;
                     break;
@@ -5965,7 +5964,7 @@
 
         function renderABResults(data) {
             console.log('📈 renderABResults called with data:', data);
-            // Zeige Results Container
+            // Show the results container
             document.getElementById('ab-results-container').style.display = 'block';
             document.getElementById('ab-placeholder').style.display = 'none';
 
@@ -6054,7 +6053,7 @@
             };
 
             const layout = {
-                title: 'Speed Trend Vergleich (Baseline vs. Test)',
+                title: 'Speed Trend Comparison (Baseline vs. Test)',
                 xaxis: { title: 'Zeitstempel' },
                 yaxis: { title: 'tokens/sec' },
                 hovermode: 'x unified',


### PR DESCRIPTION
Adapt the project to run on macOS (Apple Silicon and Intel) alongside Linux, fix an LM Studio API compatibility break, and clean up leftover German UI strings.

macOS support:
- Add core/platform_info.py: shared OS/GPU probes (system_profiler, ioreg, sysctl, sw_vers) replacing platform.system() checks that were inlined across four modules
- Mark PyGObject and distro as Linux-only (sys_platform == "linux"); PyGObject needs GTK headers macOS does not ship and blocked `pip install -r requirements.txt` outright
- Guard the unconditional `import distro` in web/app.py
- Skip the GTK tray off Linux with a one-line notice instead of spawning a process that dies on every run
- Strip DYLD_* alongside LD_* in subprocess environments
- Detect Apple Silicon GPUs (model, core count, Metal, unified memory); treat unified memory as one pool instead of summing VRAM and GTT
- Report "macOS Tahoe"/"26.6" rather than "Darwin"/"25.6.0"

setup.sh:
- Replace the Linux-only hard exit with Linux/macOS detection
- Add Homebrew support, never invoked under sudo
- Use `exec 3>>` instead of `exec {LOG_FD}>>`, which requires bash >= 4.1 and exits 127 on the bash 3.2 that macOS ships
- Use POSIX `find -perm -u+x` instead of the GNU-only `-executable`
- Detect GPUs via system_profiler; skip GTK and AMD/ROCm checks

Sudoless power and temperature via macmon:
- Add tools/macmon.py, a streaming NDJSON reader for `macmon pipe`, providing GPU temperature and power without root (powermetrics requires it). Optional: absent macmon leaves those metrics unset.
- Restores the --max-temp and --max-power guardrails on macOS

LM Studio API compatibility:
- Newer LM Studio returns a flat model key and reports quantization as an object ({name, bits} via CLI, {name, bits_per_weight} via REST) instead of encoding it in the key as "model@Q4_K_M". Every result was recording "unknown". Parse all shapes, keep the legacy key fallback.

UI fixes:
- Translate remaining German strings: dashboard headings, chart titles, button label, input placeholder, PDF report table headers and log messages
- Fix the A/B testing toggle layout. The global `input, select { width: 100% }` rule stretched the checkbox to full width, pushing its label out of the panel and under the Live-Terminal. Use the existing .checkbox-item pattern, which already sets width: auto.

Tests: 1029 passing (up from 943), coverage 81.9% -> 84.1%