### PR TITLE
fix: benchmark only local models when LM Link is active

### DIFF
--- a/cli/benchmark.py
+++ b/cli/benchmark.py
@@ -23,7 +23,7 @@ from statistics import mean, median, quantiles
 import subprocess
 import sys
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import httpx
 import psutil
@@ -277,6 +277,9 @@ class BenchmarkResult:
     intel_driver_version: Optional[str] = None
     context_length: Optional[int] = None
     model_key: Optional[str] = None
+    # LM Link device this result was measured on. Only local models are ever
+    # benchmarked, so this records which machine "local" was.
+    device_name: Optional[str] = None
     prompt_hash: Optional[str] = None
     params_hash: Optional[str] = None
     os_name: Optional[str] = None
@@ -302,6 +305,7 @@ class BenchmarkCache:
         ("intel_driver_version", "TEXT"),
         ("prompt_hash", "TEXT"),
         ("params_hash", "TEXT"),
+        ("device_name", "TEXT"),
         ("os_name", "TEXT"),
         ("os_version", "TEXT"),
         ("cpu_model", "TEXT"),
@@ -662,6 +666,7 @@ class BenchmarkCache:
                 intel_driver_version TEXT,
                 prompt_hash TEXT,
                 params_hash TEXT,
+                device_name TEXT,
                 os_name TEXT,
                 os_version TEXT,
                 cpu_model TEXT,
@@ -956,22 +961,40 @@ class BenchmarkCache:
             return BenchmarkResult(**result_dict)
         return None
 
-    def get_latest_result_for_model(self, model_key: str) -> Optional[BenchmarkResult]:
-        """Returns latest cached result for model regardless of params hash."""
+    def get_latest_result_for_model(
+        self, model_key: str, device_name: Optional[str] = None
+    ) -> Optional[BenchmarkResult]:
+        """Returns latest cached result for model regardless of params hash.
+
+        When ``device_name`` is given, rows measured on a *different* machine
+        are rejected. Rows predating device tracking carry NULL and are still
+        accepted, so existing caches stay usable.
+        """
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
 
         cursor.execute("PRAGMA table_info(benchmark_results)")
         columns = {row[1]: row[0] for row in cursor.fetchall()}
 
-        cursor.execute(
-            """
-            SELECT * FROM benchmark_results
-            WHERE model_key = ?
-            ORDER BY timestamp DESC LIMIT 1
-        """,
-            (model_key,),
-        )
+        if device_name and "device_name" in columns:
+            cursor.execute(
+                """
+                SELECT * FROM benchmark_results
+                WHERE model_key = ?
+                  AND (device_name IS NULL OR device_name = ?)
+                ORDER BY timestamp DESC LIMIT 1
+            """,
+                (model_key, device_name),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT * FROM benchmark_results
+                WHERE model_key = ?
+                ORDER BY timestamp DESC LIMIT 1
+            """,
+                (model_key,),
+            )
 
         row = cursor.fetchone()
         conn.close()
@@ -1120,6 +1143,7 @@ class BenchmarkCache:
                 result.intel_driver_version,
                 result.prompt_hash,
                 params_hash,
+                result.device_name,
                 result.os_name,
                 result.os_version,
                 result.cpu_model,
@@ -1194,7 +1218,8 @@ class BenchmarkCache:
                     prompt, context_length, temperature, top_k_sampling, top_p_sampling,
                     min_p_sampling, repeat_penalty, max_tokens, num_runs, runs_averaged_from,
                     warmup_runs, run_index, lmstudio_version, app_version, nvidia_driver_version, rocm_driver_version,
-                    intel_driver_version, prompt_hash, params_hash, os_name, os_version,
+                    intel_driver_version, prompt_hash, params_hash, device_name,
+                    os_name, os_version,
                     cpu_model, python_version, benchmark_duration_seconds, error_count,
                     n_gpu_layers, n_batch, n_threads, flash_attention, rope_freq_base,
                     rope_freq_scale, use_mmap, use_mlock, kv_cache_quant,
@@ -1638,6 +1663,13 @@ class ModelDiscovery:
     """Finds all locally installed models"""
 
     _metadata_cache: Dict[str, Dict] = {}
+    # Maps model key -> set of LM Link device identifiers holding that model.
+    # ``None`` inside the set means the model is present on this machine.
+    # A model can live on several devices at once, hence a set rather than a
+    # single value.
+    _device_cache: Dict[str, Set[Optional[str]]] = {}
+    # Maps LM Link deviceIdentifier -> human readable device name.
+    _link_peers_cache: Optional[Dict[str, str]] = None
 
     @staticmethod
     def warm_metadata_cache() -> Dict[str, Dict]:
@@ -1661,6 +1693,16 @@ class ModelDiscovery:
                     for model_data in data:
                         if model_data.get("type") == "llm":
                             key = model_data.get("modelKey")
+                            device = model_data.get("deviceIdentifier")
+                            # Record provenance for the bare key and for every
+                            # variant: variants are NOT device-prefixed, so a
+                            # remote "pub/model@q4_0" is indistinguishable from
+                            # a local one without this map.
+                            for device_key in [key, *model_data.get("variants", [])]:
+                                if device_key:
+                                    ModelDiscovery._device_cache.setdefault(
+                                        device_key, set()
+                                    ).add(device)
                             ModelDiscovery._metadata_cache[key] = {
                                 "architecture": model_data.get(
                                     "architecture", "unknown"
@@ -1705,6 +1747,125 @@ class ModelDiscovery:
                 "has_vision": False,
                 "has_tools": False,
             },
+        )
+
+    @staticmethod
+    def get_devices(model_key: str) -> Set[Optional[str]]:
+        """Returns the LM Link devices a model lives on.
+
+        ``None`` inside the result means "this machine". An empty set means
+        the device is unknown, which is treated as local by callers.
+        """
+        ModelDiscovery._get_metadata_cache()
+        devices = ModelDiscovery._device_cache.get(model_key)
+        if devices is None and "@" in model_key:
+            devices = ModelDiscovery._device_cache.get(model_key.split("@")[0])
+        return devices if devices is not None else set()
+
+    @staticmethod
+    def is_local_model(model_key: str) -> bool:
+        """Whether a model is available on this machine.
+
+        Unknown provenance counts as local: without LM Link every model is
+        local, and callers that stub out the metadata cache must keep working.
+        A model present both locally and remotely counts as local — LM Studio
+        resolves that ambiguity in favour of the local copy.
+        """
+        devices = ModelDiscovery.get_devices(model_key)
+        return not devices or None in devices
+
+    @staticmethod
+    def get_link_peers() -> Dict[str, str]:
+        """Maps LM Link device identifiers to readable names.
+
+        Best effort: returns an empty mapping when LM Link is unavailable,
+        which older LM Studio CLIs are. Never raises.
+        """
+        if ModelDiscovery._link_peers_cache is not None:
+            return ModelDiscovery._link_peers_cache
+
+        peers: Dict[str, str] = {}
+        try:
+            result = subprocess.run(
+                ["lms", "link", "status", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if result.returncode == 0:
+                data = json.loads(result.stdout)
+                for peer in data.get("peers", []):
+                    identifier = peer.get("deviceIdentifier")
+                    if identifier:
+                        peers[identifier] = peer.get("deviceName") or identifier
+                local_id = data.get("deviceIdentifier")
+                if local_id:
+                    peers[local_id] = data.get("deviceName") or local_id
+        except (
+            subprocess.SubprocessError,
+            OSError,
+            json.JSONDecodeError,
+            ValueError,
+        ) as e:
+            logger.debug("LM Link status unavailable: %s", e)
+
+        ModelDiscovery._link_peers_cache = peers
+        return peers
+
+    @staticmethod
+    def get_device_name(identifier: Optional[str]) -> str:
+        """Resolves a device identifier to a readable name."""
+        if identifier is None:
+            return "local"
+        return ModelDiscovery.get_link_peers().get(identifier) or identifier
+
+    @staticmethod
+    def get_local_device_name() -> Optional[str]:
+        """Returns this machine's LM Link device name, if known."""
+        try:
+            result = subprocess.run(
+                ["lms", "link", "status", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if result.returncode == 0:
+                return json.loads(result.stdout).get("deviceName")
+        except (
+            subprocess.SubprocessError,
+            OSError,
+            json.JSONDecodeError,
+            ValueError,
+        ) as e:
+            logger.debug("LM Link status unavailable: %s", e)
+        return None
+
+    @staticmethod
+    def _log_device_summary(local: List[str], remote: List[str]) -> None:
+        """Reports which models were kept and which were skipped as remote."""
+        logger.info("🖥️ %d local model(s)", len(local))
+        if not remote:
+            return
+
+        by_device: Dict[str, int] = {}
+        for model_key in remote:
+            for device in ModelDiscovery.get_devices(model_key):
+                if device is not None:
+                    name = ModelDiscovery.get_device_name(device)
+                    by_device[name] = by_device.get(name, 0) + 1
+        detail = ", ".join(
+            f"{count} on '{name}'" for name, count in sorted(by_device.items())
+        )
+        logger.info(
+            "🔗 LM Link active: skipping %d remote model(s)%s",
+            len(remote),
+            f" ({detail})" if detail else "",
+        )
+        logger.info(
+            "   Benchmarks run locally only — hardware telemetry measures "
+            "this machine."
         )
 
     @staticmethod
@@ -1772,8 +1933,33 @@ class ModelDiscovery:
 
     @staticmethod
     def filter_models(models: List[str], filter_args: Dict) -> List[str]:
-        """Filters models based on CLI arguments"""
-        if not filter_args:
+        """Filters models based on CLI arguments.
+
+        Remote models served via LM Link are always dropped first, before any
+        CLI filter applies. This is unconditional: hardware telemetry is
+        sampled on this machine, so a remote model's throughput would be paired
+        with local GPU temperature, power and VRAM readings.
+        """
+        filter_args = filter_args or {}
+
+        local_models = []
+        remote_models = []
+        seen = set()
+        for model_key in models:
+            # A model available on several devices is listed once per device;
+            # benchmarking it twice would just duplicate the same local run.
+            if model_key in seen:
+                continue
+            seen.add(model_key)
+            if ModelDiscovery.is_local_model(model_key):
+                local_models.append(model_key)
+            else:
+                remote_models.append(model_key)
+
+        ModelDiscovery._log_device_summary(local_models, remote_models)
+        models = local_models
+
+        if not any(filter_args.values()):
             return models
 
         filtered = []
@@ -2160,6 +2346,10 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
             "rocm_driver_version": self.get_rocm_driver_version(),
             "intel_driver_version": self.get_intel_driver_version(),
         }
+
+        # Records which machine results were measured on. Only meaningful when
+        # LM Link is set up; None otherwise.
+        self.local_device_name = ModelDiscovery.get_local_device_name()
 
         logger.info("📋 Collected version information:")
         for key, value in self.system_versions.items():
@@ -2706,6 +2896,7 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
                 )
                 result.error_count = error_count
                 result.model_key = model_key
+                result.device_name = self.local_device_name
                 result.prompt_hash = self.prompt_hash
                 result.params_hash = self.params_hash
                 result.context_length = self.context_length
@@ -3301,9 +3492,17 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
             logger.error("❌ No models found")
             return "failed"
 
+        discovered = models
         models = ModelDiscovery.filter_models(models, self.filter_args)
         if not models:
-            logger.error("❌ No models remaining after filtering")
+            if not any(ModelDiscovery.is_local_model(m) for m in discovered):
+                logger.error(
+                    "❌ No local models found — all %d model(s) live on remote "
+                    "LM Link devices. Download a model locally to benchmark it.",
+                    len(discovered),
+                )
+            else:
+                logger.error("❌ No models remaining after filtering")
             return "failed"
 
         logger.info("")
@@ -3329,7 +3528,9 @@ class LMStudioBenchmark:  # pylint: disable=too-many-instance-attributes
                 cached = self.cache.get_cached_result(model_key, self.params_hash)
                 is_fallback = False
                 if not cached:
-                    cached = self.cache.get_latest_result_for_model(model_key)
+                    cached = self.cache.get_latest_result_for_model(
+                        model_key, self.local_device_name
+                    )
                     is_fallback = cached is not None
                 if cached:
                     cached_models.append((model_key, cached))

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -2753,3 +2753,59 @@ class TestBenchmarkWebSocket:
             response = client.get("/api/dashboard/stats")
 
         assert response.status_code == 200
+
+
+class TestInstalledModelsEndpoint:
+    """Tests for GET /api/models/installed."""
+
+    _MIXED = [
+        {
+            "type": "llm",
+            "modelKey": "pub/local-only",
+            "deviceIdentifier": None,
+            "variants": ["pub/local-only@q4_k_m"],
+        },
+        {
+            "type": "llm",
+            "modelKey": "pub/remote-only",
+            "deviceIdentifier": "b64e3314560e876afdc27837698e87b0",
+            "variants": ["pub/remote-only@q4_0"],
+        },
+    ]
+
+    def test_hides_remote_lm_link_models(self):
+        """Remote models are not offered — a run would skip them anyway."""
+        import json as _json
+        client = _get_client()
+        mock_result = MagicMock(returncode=0, stdout=_json.dumps(self._MIXED))
+        with patch("subprocess.run", return_value=mock_result):
+            response = client.get("/api/models/installed")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["models"] == ["pub/local-only@q4_k_m"]
+
+    def test_keeps_model_present_on_both_devices(self):
+        """A model available locally stays listed even if also remote."""
+        import json as _json
+        client = _get_client()
+        both = [
+            {
+                "type": "llm",
+                "modelKey": "pub/on-both",
+                "deviceIdentifier": None,
+                "variants": ["pub/on-both@q6_k"],
+            },
+            {
+                "type": "llm",
+                "modelKey": "pub/on-both",
+                "deviceIdentifier": "b64e3314560e876afdc27837698e87b0",
+                "variants": ["pub/on-both@q6_k"],
+            },
+        ]
+        mock_result = MagicMock(returncode=0, stdout=_json.dumps(both))
+        with patch("subprocess.run", return_value=mock_result):
+            response = client.get("/api/models/installed")
+
+        assert response.json()["models"] == ["pub/on-both@q6_k"]

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,6 +1,9 @@
 """Tests for cli/benchmark.py."""
 from dataclasses import asdict
+import json
+import logging
 from pathlib import Path
+import subprocess
 import sys
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -519,6 +522,53 @@ class TestBenchmarkCache:
         assert cached is not None
         assert cached.model_name == "test-model"
 
+    def _save_result_with_device(self, bm, cache, device_name):
+        """Stores a minimal result carrying a device name."""
+        result = bm.BenchmarkResult(
+            model_name="test-model",
+            quantization="Q4",
+            gpu_type="NVIDIA",
+            gpu_offload=1.0,
+            vram_mb="8192",
+            avg_tokens_per_sec=55.0,
+            avg_ttft=0.3,
+            avg_gen_time=0.8,
+            prompt_tokens=10,
+            completion_tokens=50,
+            timestamp="2024-01-01T00:00:00",
+            params_size="7B",
+            architecture="llama",
+            max_context_length=4096,
+            model_size_gb=4.0,
+            has_vision=False,
+            has_tools=False,
+            tokens_per_sec_per_gb=13.75,
+            tokens_per_sec_per_billion_params=7.86,
+            inference_params_hash="infr9999",
+            device_name=device_name,
+        )
+        cache.save_result(result, "pub/test-model", "full9999", "test prompt", 2048)
+
+    def test_latest_result_rejects_foreign_device(self, tmp_path: Path):
+        """A result from another machine is not served as a fallback."""
+        bm = _import_benchmark()
+        cache = bm.BenchmarkCache(db_path=tmp_path / "cache.db")
+        self._save_result_with_device(bm, cache, "linuxpc")
+
+        assert cache.get_latest_result_for_model("pub/test-model", "MacBoy") is None
+        assert (
+            cache.get_latest_result_for_model("pub/test-model", "linuxpc") is not None
+        )
+
+    def test_latest_result_accepts_legacy_rows(self, tmp_path: Path):
+        """Rows predating device tracking stay usable."""
+        bm = _import_benchmark()
+        cache = bm.BenchmarkCache(db_path=tmp_path / "cache.db")
+        self._save_result_with_device(bm, cache, None)
+
+        cached = cache.get_latest_result_for_model("pub/test-model", "MacBoy")
+        assert cached is not None
+
     def test_export_to_json(self, tmp_path: Path, monkeypatch):
         """export_to_json creates a JSON file."""
         bm = _import_benchmark()
@@ -796,6 +846,191 @@ class TestModelDiscovery:
         with patch("benchmark.METADATA_DATABASE_FILE", non_existent):
             result = bm.ModelDiscovery.get_scraped_metadata("pub/model")
         assert result == {}
+
+
+MIXED_DEVICE_MODELS = [
+    {
+        "type": "llm",
+        "modelKey": "pub/local-only",
+        "deviceIdentifier": None,
+        "variants": ["pub/local-only@q4_k_m"],
+    },
+    {
+        # Remote variants are NOT device-prefixed — they look exactly like
+        # local ones, which is why provenance must come from deviceIdentifier.
+        "type": "llm",
+        "modelKey": "pub/remote-only",
+        "deviceIdentifier": "b64e3314560e876afdc27837698e87b0",
+        "path": "b64e3314560e876afdc27837698e87b0:pub/remote-only",
+        "variants": ["pub/remote-only@q4_0", "pub/remote-only@q8_0"],
+    },
+    {
+        "type": "llm",
+        "modelKey": "pub/on-both",
+        "deviceIdentifier": None,
+        "variants": ["pub/on-both@q6_k"],
+    },
+    {
+        "type": "llm",
+        "modelKey": "pub/on-both",
+        "deviceIdentifier": "b64e3314560e876afdc27837698e87b0",
+        "variants": ["pub/on-both@q6_k", "pub/on-both@q4_k_m"],
+    },
+    {"type": "embedding", "modelKey": "pub/embed", "deviceIdentifier": None},
+]
+
+LINK_STATUS_PAYLOAD = {
+    "status": "online",
+    "peers": [
+        {
+            "deviceIdentifier": "b64e3314560e876afdc27837698e87b0",
+            "deviceName": "linuxpc",
+            "status": "connected",
+        }
+    ],
+    "deviceIdentifier": "cd3e835a08a94bf49505ef793dfdae7a",
+    "deviceName": "MacBoy",
+}
+
+
+class TestLocalOnlyDiscovery:
+    """Remote LM Link models must never be benchmarked."""
+
+    def setup_method(self):
+        bm = _import_benchmark()
+        bm.ModelDiscovery._metadata_cache = {}
+        bm.ModelDiscovery._device_cache = {}
+        bm.ModelDiscovery._link_peers_cache = None
+
+    teardown_method = setup_method
+
+    def _load_devices(self, bm):
+        """Populates the device cache from the mixed fixture."""
+        mock_result = MagicMock(returncode=0, stdout=json.dumps(MIXED_DEVICE_MODELS))
+        with patch("subprocess.run", return_value=mock_result):
+            bm.ModelDiscovery.warm_metadata_cache()
+
+    def test_device_cache_records_provenance(self):
+        """deviceIdentifier lands in the device cache per variant."""
+        bm = _import_benchmark()
+        self._load_devices(bm)
+        assert bm.ModelDiscovery.get_devices("pub/local-only@q4_k_m") == {None}
+        assert bm.ModelDiscovery.get_devices("pub/remote-only@q4_0") == {
+            "b64e3314560e876afdc27837698e87b0"
+        }
+
+    def test_get_devices_falls_back_to_base_key(self):
+        """Unknown variant resolves through its base model key."""
+        bm = _import_benchmark()
+        self._load_devices(bm)
+        assert bm.ModelDiscovery.get_devices("pub/remote-only@unknown") == {
+            "b64e3314560e876afdc27837698e87b0"
+        }
+
+    def test_is_local_model_classification(self):
+        """Local, remote and dual-device models are classified correctly."""
+        bm = _import_benchmark()
+        self._load_devices(bm)
+        assert bm.ModelDiscovery.is_local_model("pub/local-only@q4_k_m") is True
+        assert bm.ModelDiscovery.is_local_model("pub/remote-only@q4_0") is False
+        # Present on both devices: LM Studio loads the local copy.
+        assert bm.ModelDiscovery.is_local_model("pub/on-both@q6_k") is True
+
+    def test_unknown_model_counts_as_local(self):
+        """Absent provenance must not exclude a model."""
+        bm = _import_benchmark()
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert bm.ModelDiscovery.is_local_model("pub/never-seen") is True
+
+    def test_filter_models_drops_remote_with_empty_filters(self):
+        """Remote models are dropped even when no CLI filter is active."""
+        bm = _import_benchmark()
+        self._load_devices(bm)
+        models = [
+            "pub/local-only@q4_k_m",
+            "pub/remote-only@q4_0",
+            "pub/remote-only@q8_0",
+            "pub/on-both@q6_k",
+        ]
+        result = bm.ModelDiscovery.filter_models(models, {})
+        assert result == ["pub/local-only@q4_k_m", "pub/on-both@q6_k"]
+
+    def test_filter_models_drops_remote_with_none_filters(self):
+        """filter_args=None must not bypass the local-only guard."""
+        bm = _import_benchmark()
+        self._load_devices(bm)
+        result = bm.ModelDiscovery.filter_models(
+            ["pub/local-only@q4_k_m", "pub/remote-only@q4_0"], None
+        )
+        assert result == ["pub/local-only@q4_k_m"]
+
+    def test_filter_models_combines_with_other_filters(self):
+        """Remote exclusion applies alongside regular filters."""
+        bm = _import_benchmark()
+        self._load_devices(bm)
+        models = ["pub/local-only@q4_k_m", "pub/remote-only@q4_0", "pub/on-both@q6_k"]
+        result = bm.ModelDiscovery.filter_models(
+            models, {"include_models": "on-both"}
+        )
+        assert result == ["pub/on-both@q6_k"]
+
+    def test_dual_device_model_is_not_duplicated(self):
+        """A model listed once per device is benchmarked only once."""
+        bm = _import_benchmark()
+        self._load_devices(bm)
+        result = bm.ModelDiscovery.filter_models(
+            ["pub/on-both@q6_k", "pub/on-both@q6_k", "pub/local-only@q4_k_m"], {}
+        )
+        assert result == ["pub/on-both@q6_k", "pub/local-only@q4_k_m"]
+
+    def test_empty_device_cache_keeps_all_models(self):
+        """Stubbed metadata cache leaves every model benchmarkable."""
+        bm = _import_benchmark()
+        with patch.object(bm.ModelDiscovery, "_get_metadata_cache", return_value={}):
+            result = bm.ModelDiscovery.filter_models(["a@q4", "b@q4"], {})
+        assert result == ["a@q4", "b@q4"]
+
+    def test_get_link_peers_resolves_names(self):
+        """lms link status maps identifiers to readable names."""
+        bm = _import_benchmark()
+        mock_result = MagicMock(returncode=0, stdout=json.dumps(LINK_STATUS_PAYLOAD))
+        with patch("subprocess.run", return_value=mock_result):
+            peers = bm.ModelDiscovery.get_link_peers()
+        assert peers["b64e3314560e876afdc27837698e87b0"] == "linuxpc"
+        assert peers["cd3e835a08a94bf49505ef793dfdae7a"] == "MacBoy"
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            {"return_value": MagicMock(returncode=1, stdout="")},
+            {"side_effect": FileNotFoundError("lms")},
+            {"side_effect": subprocess.TimeoutExpired("lms", 10)},
+            {"return_value": MagicMock(returncode=0, stdout="not json")},
+        ],
+    )
+    def test_get_link_peers_never_raises(self, failure):
+        """Missing or broken lms link degrades to an empty mapping."""
+        bm = _import_benchmark()
+        with patch("subprocess.run", **failure):
+            assert bm.ModelDiscovery.get_link_peers() == {}
+
+    def test_device_summary_names_remote_host(self, caplog):
+        """The skip message names the host and the counts."""
+        bm = _import_benchmark()
+        self._load_devices(bm)
+        with patch.object(
+            bm.ModelDiscovery,
+            "get_link_peers",
+            return_value={"b64e3314560e876afdc27837698e87b0": "linuxpc"},
+        ):
+            with caplog.at_level(logging.INFO):
+                bm.ModelDiscovery.filter_models(
+                    ["pub/local-only@q4_k_m", "pub/remote-only@q4_0"], {}
+                )
+        text = caplog.text
+        assert "1 local model" in text
+        assert "skipping 1 remote" in text
+        assert "linuxpc" in text
 
 
 class TestLMStudioBenchmarkStaticMethods:

--- a/web/app.py
+++ b/web/app.py
@@ -2287,18 +2287,28 @@ async def get_installed_models() -> dict:
         parsed = json.loads(result.stdout)
         model_ids: list[str] = []
         seen: set[str] = set()
+        remote_only: set[str] = set()
         for item in parsed:
+            # Models served from a remote LM Link device are not benchmarkable:
+            # hardware telemetry samples this machine. Offering them here would
+            # list models that a run then silently skips.
+            is_remote = item.get("deviceIdentifier") is not None
             variants = item.get("variants") or []
-            if variants:
-                for variant in variants:
-                    if variant and variant not in seen:
-                        model_ids.append(variant)
-                        seen.add(variant)
-                continue
-            model_key = item.get("modelKey")
-            if model_key and model_key not in seen:
-                model_ids.append(model_key)
-                seen.add(model_key)
+            keys = variants if variants else [item.get("modelKey")]
+            for key in keys:
+                if not key:
+                    continue
+                if is_remote:
+                    remote_only.add(key)
+                    continue
+                if key not in seen:
+                    model_ids.append(key)
+                    seen.add(key)
+        # A model present both locally and remotely stays listed: LM Studio
+        # resolves that ambiguity in favour of the local copy.
+        skipped = len(remote_only - seen)
+        if skipped:
+            logger.info("🔗 %d remote LM Link model(s) hidden from picker", skipped)
 
         return {"success": True, "models": model_ids}
     except json.JSONDecodeError as e:


### PR DESCRIPTION
Model discovery returned models from remote LM Link devices alongside local ones and had no way to tell them apart, so remote models were benchmarked while hardware telemetry sampled the local machine. Reports combined remote throughput with local GPU temperature, power and VRAM without any indication of the mismatch.

Observed locally: 79 models discovered, 11 local, 68 on a remote host, and the log reported "72/72 models remaining".

`lms ls --json` exposes a `deviceIdentifier` per entry (null = local), which discovery previously ignored. Record it per variant — variants are not device-prefixed, so a remote "pub/model@q4_0" is otherwise identical to a local one — and drop remote models in filter_models before any CLI filter applies. The split sits above the early return for empty filter_args, which would otherwise let callers bypass the guard.

Unknown provenance counts as local, so setups without LM Link and tests that stub the metadata cache are unaffected. A model present on both a local and a remote device counts as local: LM Studio resolves that ambiguity in favour of the local copy (verified against lms load). Such models are listed once per device, so results are deduplicated.

Also:
- record device_name on BenchmarkResult and persist it, so the loose cache fallback no longer serves another machine's result for a model; rows predating the column are NULL and stay usable
- hide remote models from /api/models/installed, which offered models that a run would then skip