### PR TITLE
Fix Codacy coverage upload by using account token mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,11 @@ jobs:
         if: ${{ matrix.run-coverage && github.repository == 'Ajimaru/LM-Studio-Bench' }}
         env:
           CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
-          CODACY_ORGANIZATION_PROVIDER: ${{ vars.CODACY_ORGANIZATION_PROVIDER }}
-          CODACY_USERNAME: ${{ vars.CODACY_USERNAME }}
-          CODACY_PROJECT_NAME: ${{ vars.CODACY_PROJECT_NAME }}
+          # Provider must be one of gh, ghe, gl, gle, bb, bbe — a friendly
+          # name like "GitHub" is rejected, so normalise it below.
+          CODACY_ORGANIZATION_PROVIDER: ${{ vars.CODACY_ORGANIZATION_PROVIDER || 'gh' }}
+          CODACY_USERNAME: ${{ vars.CODACY_USERNAME || github.repository_owner }}
+          CODACY_PROJECT_NAME: ${{ vars.CODACY_PROJECT_NAME || github.event.repository.name }}
         continue-on-error: true
         run: |
           if [ -z "${CODACY_API_TOKEN}" ]; then
@@ -129,12 +131,28 @@ jobs:
             exit 0
           fi
 
+          # Accept a friendly provider name and map it to the code the
+          # reporter expects.
+          case "$(printf '%s' "${CODACY_ORGANIZATION_PROVIDER}" | tr '[:upper:]' '[:lower:]')" in
+            github|gh)        CODACY_ORGANIZATION_PROVIDER=gh ;;
+            githubenterprise) CODACY_ORGANIZATION_PROVIDER=ghe ;;
+            gitlab)           CODACY_ORGANIZATION_PROVIDER=gl ;;
+            bitbucket)        CODACY_ORGANIZATION_PROVIDER=bb ;;
+          esac
+          export CODACY_ORGANIZATION_PROVIDER
+          echo "Codacy target: ${CODACY_ORGANIZATION_PROVIDER}/${CODACY_USERNAME}/${CODACY_PROJECT_NAME}"
+
+          # The reporter reads CODACY_API_TOKEN plus the three CODACY_*
+          # identification variables from the environment. Passing the account
+          # token via -t would select the *project* token mode instead, which
+          # fails with "Request URL not found" (-t is --project-token,
+          # -a is --api-token).
           set +e
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml -t "$CODACY_API_TOKEN"
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml
           codacy_exit=$?
           set -e
 
           if [ "$codacy_exit" -ne 0 ]; then
-            echo "Codacy upload failed (likely project/token mapping issue); continuing"
+            echo "Codacy upload failed (exit ${codacy_exit}); continuing"
             exit 0
           fi


### PR DESCRIPTION
This pull request updates the Codacy coverage reporting step in the CI workflow to improve robustness and compatibility. The main changes ensure that required environment variables have sensible defaults and that provider names are normalized to the expected codes.

**Improvements to Codacy coverage reporting:**

* Added default values for `CODACY_ORGANIZATION_PROVIDER`, `CODACY_USERNAME`, and `CODACY_PROJECT_NAME` to prevent failures when these variables are unset.
* Introduced logic to normalize friendly provider names (like "GitHub") to Codacy's expected codes (e.g., "gh", "ghe"), ensuring compatibility with Codacy's API.
* Updated the Codacy upload command to rely on environment variables for authentication, avoiding the use of the `-t` flag which could cause project/token mapping issues.
* Improved logging by echoing the Codacy target and providing clearer failure messages with exit codes.